### PR TITLE
Make winrm binary exit with the invoked command's exit code

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -18,18 +18,18 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/masterzen/winrm/winrm"
 	"os"
-	"fmt"
 )
 
 func main() {
 	var (
 		hostname string
-		user string
-		pass string
-		cmd string
-		port int
+		user     string
+		pass     string
+		cmd      string
+		port     int
 	)
 
 	flag.StringVar(&hostname, "hostname", "localhost", "winrm host")
@@ -40,9 +40,11 @@ func main() {
 
 	cmd = flag.Arg(0)
 	client := winrm.NewClient(&winrm.Endpoint{hostname, port}, user, pass)
-	err := client.RunWithInput(cmd, os.Stdout, os.Stderr, os.Stdin)
+	exitCode, err := client.RunWithInput(cmd, os.Stdout, os.Stderr, os.Stdin)
 
 	if err != nil {
 		fmt.Println(err)
 	}
+
+	os.Exit(exitCode)
 }

--- a/winrm/client.go
+++ b/winrm/client.go
@@ -103,20 +103,20 @@ func (client *Client) RunWithString(command string, stdin string) (stdout string
 // Warning stdin (not stdout/stderr) are bufferized, which means reading only one byte in stdin will
 // send a winrm http packet to the remote host. If stdin is a pipe, it might be better for
 // performance reasons to buffer it.
-func (client *Client) RunWithInput(command string, stdout io.Writer, stderr io.Writer, stdin io.Reader) (err error) {
+func (client *Client) RunWithInput(command string, stdout io.Writer, stderr io.Writer, stdin io.Reader) (exitCode int, err error) {
 	shell, err := client.CreateShell()
 	if err != nil {
-		return err
+		return 1, err
 	}
 	defer shell.Close()
 	var cmd *Command
 	cmd, err = shell.Execute(command)
 	if err != nil {
-		return err
+		return 1, err
 	}
 	go io.Copy(cmd.Stdin, stdin)
 	go io.Copy(stdout, cmd.Stdout)
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
-	return nil
+	return cmd.exitCode, nil
 }

--- a/winrm/http_test.go
+++ b/winrm/http_test.go
@@ -1,10 +1,10 @@
 package winrm
 
 import (
+	. "launchpad.net/gocheck"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	. "launchpad.net/gocheck"
 )
 
 var response = `<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">


### PR DESCRIPTION
Resolves #7.  This passes the exit code of the command as the exit code of `winrm`.

I had to add an additional return argument to `RunWithInput`; I don't know what the API stability of this method needs to be, so if it can't change I'll add another method instead.
