### PR TITLE
Encode command using XML EscapeText

### DIFF
--- a/winrm/request.go
+++ b/winrm/request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"github.com/masterzen/winrm/soap"
 	"github.com/nu7hatch/gouuid"
+	"strings"
 )
 
 func genUUID() string {
@@ -48,6 +49,12 @@ func NewExecuteCommandRequest(uri string, shellId string, command string, params
 	}
 	message = soap.NewMessage()
 	defaultHeaders(uri, message, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).AddOption(soap.NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "FALSE")).Build()
+
+	// WinRM only wants a specific subset of characters encoded.  If you try
+	// to encode quotes or escape like &#34;, it won't work.
+	command = strings.Replace(command, "&", "&amp;", -1)
+	command = strings.Replace(command, "<", "&lt;", -1)
+	command = strings.Replace(command, ">", "&gt;", -1)
 
 	body := message.CreateBodyElement("CommandLine", soap.NS_WIN_SHELL)
 	commandElement := message.CreateElement(body, "Command", soap.NS_WIN_SHELL)

--- a/winrm/request_test.go
+++ b/winrm/request_test.go
@@ -46,6 +46,17 @@ func (s *WinRMSuite) TestExecuteCommandRequest(c *C) {
 	assertXPath(c, request.Doc(), "//rsp:CommandLine/rsp:Command", "\"ipconfig /all\"")
 }
 
+func (s *WinRMSuite) TestExecuteCommandRequestEscaped(c *C) {
+	request := NewExecuteCommandRequest("http://localhost", "SHELLID", "&<>\"'", nil)
+	defer request.Free()
+
+	assertXPath(c, request.Doc(), "//a:Action", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command")
+	assertXPath(c, request.Doc(), "//a:To", "http://localhost")
+	assertXPath(c, request.Doc(), "//w:Selector[@Name=\"ShellId\"]", "SHELLID")
+	assertXPath(c, request.Doc(), "//w:Option[@Name=\"WINRS_CONSOLEMODE_STDIN\"]", "FALSE")
+	assertXPath(c, request.Doc(), "//rsp:CommandLine/rsp:Command", "\"&<>\"'\"")
+}
+
 func (s *WinRMSuite) TestGetOutputRequest(c *C) {
 	request := NewGetOutputRequest("http://localhost", "SHELLID", "COMMANDID", "stdout stderr", nil)
 	defer request.Free()


### PR DESCRIPTION
Fixes #9.  The command passed through to WinRM needs to be XML escaped.
