### PR TITLE
Shell execute with arguments

### DIFF
--- a/winrm/request.go
+++ b/winrm/request.go
@@ -47,7 +47,7 @@ func NewDeleteShellRequest(uri string, shellId string, params *Parameters) (mess
 	return
 }
 
-func NewExecuteCommandRequest(uri string, shellId string, command, arguments string, params *Parameters) (message *soap.SoapMessage) {
+func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, params *Parameters) (message *soap.SoapMessage) {
 	if params == nil {
 		params = DefaultParameters()
 	}
@@ -61,10 +61,10 @@ func NewExecuteCommandRequest(uri string, shellId string, command, arguments str
 	commandElement := message.CreateElement(body, "Command", soap.NS_WIN_SHELL)
 	commandElement.SetContent(command)
 
-	if arguments != "" {
-		arguments = "<![CDATA[" + arguments + "]]>"
+	for _, arg := range arguments {
+		arg = "<![CDATA[" + arg + "]]>"
 		argumentsElement := message.CreateElement(body, "Arguments", soap.NS_WIN_SHELL)
-		argumentsElement.SetContent(arguments)
+		argumentsElement.SetContent(arg)
 	}
 
 	return

--- a/winrm/shell.go
+++ b/winrm/shell.go
@@ -7,12 +7,7 @@ type Shell struct {
 }
 
 // Execute command on the given Shell, returning either an error or a Command
-func (shell *Shell) Execute(command string) (cmd *Command, err error) {
-	return shell.ExecuteWithArguments(command, "")
-}
-
-// Execute command wth arguments on the given Shell, returning either an error or a Command
-func (shell *Shell) ExecuteWithArguments(command, arguments string) (cmd *Command, err error) {
+func (shell *Shell) Execute(command string, arguments ...string) (cmd *Command, err error) {
 	request := NewExecuteCommandRequest(shell.client.url, shell.ShellId, command, arguments, &shell.client.Parameters)
 	defer request.Free()
 


### PR DESCRIPTION
I'd like to be able to use the `Arguments` element of the `CommandLine`. An example: [msdn/Remote Shell Examples](http://msdn.microsoft.com/en-us/library/cc251731.aspx)

```
<s:Body>
  <rsp:CommandLine
    xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
    <rsp:Command>del</rsp:Command>
    <rsp:Arguments>/p</rsp:Arguments>
    <rsp:Arguments>
      d:\temp\out.txt
    </rsp:Arguments>
  </rsp:CommandLine>
</s:Body>
```
