### PR TITLE
Return the ExitCode() from the command

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -19,8 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/masterzen/winrm/winrm"
 	"os"
+
+	"github.com/masterzen/winrm/winrm"
 )
 
 func main() {
@@ -40,12 +41,12 @@ func main() {
 
 	cmd = flag.Arg(0)
 	client := winrm.NewClient(&winrm.Endpoint{hostname, port}, user, pass)
-	err := client.RunWithInput(cmd, os.Stdout, os.Stderr, os.Stdin)
+	exitCode, err := client.RunWithInput(cmd, os.Stdout, os.Stderr, os.Stdin)
 
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	os.Exit(0)
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
Fixes masterzen/winrm#17

When the command exits, the ExitCode is returned. In the case of an error, 0 is the exit code returned, as the user should be checking the error.