### PR TITLE
Https with cacerts

### DIFF
--- a/winrm/client_test.go
+++ b/winrm/client_test.go
@@ -6,14 +6,17 @@ import (
 )
 
 func (s *WinRMSuite) TestNewClient(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+
+	c.Assert(err, IsNil)
 	c.Assert(client.url, Equals, "http://localhost:5985/wsman")
 	c.Assert(client.username, Equals, "Administrator")
 	c.Assert(client.password, Equals, "v3r1S3cre7")
 }
 
 func (s *WinRMSuite) TestClientCreateShell(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
 		c.Assert(message.String(), Contains, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create")
 		return createShellResponse, nil

--- a/winrm/command_test.go
+++ b/winrm/command_test.go
@@ -2,14 +2,17 @@ package winrm
 
 import (
 	"bytes"
-	"github.com/masterzen/winrm/soap"
 	"io"
-	. "gopkg.in/check.v1"
 	"strings"
+
+	"github.com/masterzen/winrm/soap"
+	. "gopkg.in/check.v1"
 )
 
 func (s *WinRMSuite) TestExecuteCommand(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
 	count := 0
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
@@ -43,7 +46,9 @@ func (s *WinRMSuite) TestExecuteCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestStdinCommand(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
 	count := 0
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {

--- a/winrm/endpoint.go
+++ b/winrm/endpoint.go
@@ -3,10 +3,20 @@ package winrm
 import "fmt"
 
 type Endpoint struct {
-	Host string
-	Port int
+	Host     string
+	Port     int
+	HTTPS    bool
+	Insecure bool
+	CACert   *[]byte
 }
 
 func (ep *Endpoint) url() string {
-	return fmt.Sprintf("http://%s:%d/wsman", ep.Host, ep.Port)
+	var scheme string
+	if ep.HTTPS {
+		scheme = "https"
+	} else {
+		scheme = "http"
+	}
+
+	return fmt.Sprintf("%s://%s:%d/wsman", scheme, ep.Host, ep.Port)
 }

--- a/winrm/endpoint_test.go
+++ b/winrm/endpoint_test.go
@@ -4,7 +4,12 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *WinRMSuite) TestEndpointUrl(c *C) {
-	endpoint := &Endpoint{"abc", 123}
+func (s *WinRMSuite) TestEndpointUrlHttp(c *C) {
+	endpoint := &Endpoint{Host: "abc", Port: 123}
 	c.Assert(endpoint.url(), Equals, "http://abc:123/wsman")
+}
+
+func (s *WinRMSuite) TestEndpointUrlHttps(c *C) {
+	endpoint := &Endpoint{Host: "abc", Port: 123, HTTPS: true}
+	c.Assert(endpoint.url(), Equals, "https://abc:123/wsman")
 }

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -2,10 +2,11 @@ package winrm
 
 import (
 	"fmt"
-	"github.com/masterzen/winrm/soap"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/masterzen/winrm/soap"
 )
 
 var soapXML string = "application/soap+xml"
@@ -32,7 +33,7 @@ func body(response *http.Response) (content string, err error) {
 }
 
 func Http_post(client *Client, request *soap.SoapMessage) (response string, err error) {
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Transport: client.transport}
 
 	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
 	if err != nil {

--- a/winrm/http_test.go
+++ b/winrm/http_test.go
@@ -1,10 +1,11 @@
 package winrm
 
 import (
-	. "gopkg.in/check.v1"
 	"net"
 	"net/http"
 	"net/http/httptest"
+
+	. "gopkg.in/check.v1"
 )
 
 var response = `<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
@@ -52,7 +53,8 @@ func (s *WinRMSuite) TestHttpRequest(c *C) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(&Endpoint{"localhost", 5985}, "test", "test")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "test", "test")
+	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()
 	if err != nil {
 		c.Fatalf("Can't create shell %s", err)

--- a/winrm/powershell.go
+++ b/winrm/powershell.go
@@ -7,7 +7,6 @@ import (
 
 // Wraps a PowerShell script and prepares it for execution by the winrm client
 func Powershell(psCmd string) string {
-
 	// 2 byte chars to make PowerShell happy
 	wideCmd := ""
 	for _, b := range []byte(psCmd) {

--- a/winrm/shell_test.go
+++ b/winrm/shell_test.go
@@ -6,7 +6,9 @@ import (
 )
 
 func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
 	first := true
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
@@ -25,7 +27,9 @@ func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
 }
 
 func (s *WinRMSuite) TestShellCloseResponse(c *C) {
-	client := NewClient(&Endpoint{"localhost", 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
 		c.Assert(message.String(), Contains, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete")


### PR DESCRIPTION
This addresses #19 -

Adds a -https flag, which forces communication to https
Adds a -insecure flag, which allows self-signed certificates to work (bypassing cert validation)
Adds a -cacert flag, which allows you to specify the CA certificate to use during https (used for when the CA is a private CA, and not part of your system CA cert store)

This means that creating a client can now fail, if the CA cert provided is bad.