### PR TITLE
Ensure error is returned if network or HTTP error occurs during command execution

### DIFF
--- a/winrm/client.go
+++ b/winrm/client.go
@@ -112,7 +112,7 @@ func (client *Client) Run(command string, stdout io.Writer, stderr io.Writer) (e
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
 	shell.Close()
-	return cmd.ExitCode(), nil
+	return cmd.ExitCode(), cmd.err
 }
 
 // Run will run command on the the remote host, returning the process stdout and stderr
@@ -135,7 +135,7 @@ func (client *Client) RunWithString(command string, stdin string) (stdout string
 	go io.Copy(&outWriter, cmd.Stdout)
 	go io.Copy(&errWriter, cmd.Stderr)
 	cmd.Wait()
-	return outWriter.String(), errWriter.String(), cmd.ExitCode(), nil
+	return outWriter.String(), errWriter.String(), cmd.ExitCode(), cmd.err
 }
 
 // Run will run command on the the remote host, writing the process stdout and stderr to
@@ -158,5 +158,5 @@ func (client *Client) RunWithInput(command string, stdout io.Writer, stderr io.W
 	go io.Copy(stdout, cmd.Stdout)
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
-	return cmd.ExitCode(), nil
+	return cmd.ExitCode(), cmd.err
 }

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -26,6 +26,7 @@ type Command struct {
 	commandId string
 	exitCode  int
 	finished  bool
+	err       error
 
 	Stdin  *commandWriter
 	Stdout *commandReader
@@ -35,7 +36,7 @@ type Command struct {
 }
 
 func newCommand(shell *Shell, commandId string) *Command {
-	command := &Command{shell: shell, client: shell.client, commandId: commandId, done: make(chan bool)}
+	command := &Command{shell: shell, client: shell.client, commandId: commandId, exitCode: 1, err: nil, done: make(chan bool)}
 	command.Stdin = &commandWriter{Command: command, eof: false}
 	command.Stdout = newCommandReader("stdout", command)
 	command.Stderr = newCommandReader("stderr", command)
@@ -56,8 +57,9 @@ func fetchOutput(command *Command) {
 		case <-command.done:
 			break
 		default:
-			finished, _ := command.slurpAllOutput()
+			finished, err := command.slurpAllOutput()
 			if finished {
+				command.err = err
 				command.done <- true
 				break
 			}


### PR DESCRIPTION
Currently if an error occurs during command execution (such as a non-200 status code from WinRM server or a network interruption), WinRM will exit with an error code of 0 and not indicate that an error has occurred.

This ensures the error is passed through from `slurpAllOutput` to the return code of the program.

This is also how I discovered that with a Windows 8.1 remote host, I was getting the following error (due to the command not outputting data to stdout / stderr frequently enough):

```
http error: 500 - <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action><a:MessageID>uuid:B151B169-93FA-4738-8826-A929F0DB280F</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:f608b328-26a1-4de5-6e4b-a812045fde6c</a:RelatesTo></s:Header><s:Body><s:Fault><s:Code><s:Value>s:Receiver</s:Value><s:Subcode><s:Value>w:TimedOut</s:Value></s:Subcode></s:Code><s:Reason><s:Text xml:lang="en-US">The WS-Management service cannot complete the operation within the time specified in OperationTimeout.  </s:Text></s:Reason><s:Detail><f:WSManFault xmlns:f="http://schemas.microsoft.com/wbem/wsman/1/wsmanfault" Code="2150858793" Machine="10.0.241.27"><f:Message>The WS-Management service cannot complete the operation within the time specified in OperationTimeout.  </f:Message></f:WSManFault></s:Detail></s:Fault></s:Body></s:Envelope>
```