### PR TITLE
Fix an issue where no output for 60 seconds would throw an error

### DIFF
--- a/winrm/client.go
+++ b/winrm/client.go
@@ -112,7 +112,7 @@ func (client *Client) Run(command string, stdout io.Writer, stderr io.Writer) (e
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
 	shell.Close()
-	return cmd.ExitCode(), nil
+	return cmd.ExitCode(), cmd.err
 }
 
 // Run will run command on the the remote host, returning the process stdout and stderr
@@ -135,7 +135,7 @@ func (client *Client) RunWithString(command string, stdin string) (stdout string
 	go io.Copy(&outWriter, cmd.Stdout)
 	go io.Copy(&errWriter, cmd.Stderr)
 	cmd.Wait()
-	return outWriter.String(), errWriter.String(), cmd.ExitCode(), nil
+	return outWriter.String(), errWriter.String(), cmd.ExitCode(), cmd.err
 }
 
 // Run will run command on the the remote host, writing the process stdout and stderr to
@@ -158,5 +158,5 @@ func (client *Client) RunWithInput(command string, stdout io.Writer, stderr io.W
 	go io.Copy(stdout, cmd.Stdout)
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
-	return cmd.ExitCode(), nil
+	return cmd.ExitCode(), cmd.err
 }

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -26,6 +26,7 @@ type Command struct {
 	commandId string
 	exitCode  int
 	finished  bool
+	err       error
 
 	Stdin  *commandWriter
 	Stdout *commandReader
@@ -35,7 +36,7 @@ type Command struct {
 }
 
 func newCommand(shell *Shell, commandId string) *Command {
-	command := &Command{shell: shell, client: shell.client, commandId: commandId, done: make(chan bool)}
+	command := &Command{shell: shell, client: shell.client, commandId: commandId, exitCode: 1, err: nil, done: make(chan bool)}
 	command.Stdin = &commandWriter{Command: command, eof: false}
 	command.Stdout = newCommandReader("stdout", command)
 	command.Stderr = newCommandReader("stderr", command)
@@ -56,8 +57,9 @@ func fetchOutput(command *Command) {
 		case <-command.done:
 			break
 		default:
-			finished, _ := command.slurpAllOutput()
+			finished, err := command.slurpAllOutput()
 			if finished {
+				command.err = err
 				command.done <- true
 				break
 			}

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"strings"
 )
 
 type commandWriter struct {
@@ -105,6 +106,11 @@ func (command *Command) slurpAllOutput() (finished bool, err error) {
 
 	response, err := command.client.sendRequest(request)
 	if err != nil {
+		if strings.Contains(err.Error(), "OperationTimeout") {
+			// Operation timeout because there was no command output
+			return
+		}
+
 		command.Stderr.write.CloseWithError(err)
 		command.Stdout.write.CloseWithError(err)
 		return true, err


### PR DESCRIPTION
This builds on #24 by fixing an issue where `winrm` would error if the command being run didn't output any data to standard output or standard error for over 60 seconds.