### PR TITLE
Fix winrm handling of early connection termination or timeout

### DIFF
--- a/winrm/client.go
+++ b/winrm/client.go
@@ -143,10 +143,10 @@ func (client *Client) Run(command string, stdout io.Writer, stderr io.Writer) (e
 	if err != nil {
 		return 0, err
 	}
+	defer shell.Close()
 	go io.Copy(stdout, cmd.Stdout)
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
-	shell.Close()
 	return cmd.ExitCode(), cmd.err
 }
 

--- a/winrm/client.go
+++ b/winrm/client.go
@@ -107,6 +107,9 @@ func (client *Client) CreateShell() (shell *Shell, err error) {
 }
 
 func (client *Client) sendRequest(request *soap.SoapMessage) (response string, err error) {
+	if errorCode, err := client.check(); errorCode != 0 {
+		return "", err
+	}
 	return client.http(client, request)
 }
 

--- a/winrm/client_test.go
+++ b/winrm/client_test.go
@@ -1,6 +1,8 @@
 package winrm
 
 import (
+	"fmt"
+
 	"github.com/masterzen/winrm/soap"
 	. "gopkg.in/check.v1"
 )
@@ -24,4 +26,128 @@ func (s *WinRMSuite) TestClientCreateShell(c *C) {
 
 	shell, _ := client.CreateShell()
 	c.Assert(shell.ShellId, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}
+
+func (s *WinRMSuite) TestClientSendRequestError(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
+	count := 0
+	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
+		switch count {
+		case 0:
+			{
+				count = 1
+				return executeCommandResponse, nil
+			}
+		case 1:
+			{
+				count = 2
+				return outputResponse, nil
+			}
+		default:
+			{
+				return doneCommandResponse, nil
+			}
+		}
+	}
+	cmd, _ := shell.Execute("ipconfig /all")
+
+	// Test execute again after no error, shuold work
+	count = 0
+	command := "ipconfig /all"
+	request := NewExecuteCommandRequest(shell.client.url, shell.ShellId, command, nil, &shell.client.Parameters)
+
+	_, err = shell.client.sendRequest(request)
+	c.Assert(err, IsNil)
+
+	// If client has an error code, sendRequest should return an error
+	cmd.err = fmt.Errorf("")
+	cmd.exitCode = 0
+	client.err = fmt.Errorf("Test /wsman: EOF")
+	count = 0
+	_, err = shell.client.sendRequest(request)
+	c.Assert(err.Error(), NotNil)
+}
+
+func (s *WinRMSuite) TestErrorOnClient(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
+	// Test known errors return properly exit codes and message
+	var cmd *Command
+	var exitCode int
+
+	client.err = fmt.Errorf("Test /wsman: EOF")
+	// Test Message
+	err = client.Error(cmd)
+	c.Assert(err.Error(), Equals, "A connection terminated unexpectedly, error while sending request to endpoint: Test /wsman: EOF")
+	// Test ExitCode
+	exitCode = client.ExitCode(cmd)
+	c.Assert(exitCode, Equals, 16000)
+
+	client.err = fmt.Errorf("Test OperationTimeout")
+	err = client.Error(cmd)
+	c.Assert(err.Error(), Equals, "Operation timeout because there was no command output: Test OperationTimeout")
+	exitCode = client.ExitCode(cmd)
+	c.Assert(exitCode, Equals, 16001)
+
+	// Test no message or exitcode is return if no error
+	client.err = fmt.Errorf("")
+	err = client.Error(cmd)
+	c.Assert(err, IsNil)
+	exitCode = client.ExitCode(cmd)
+	c.Assert(exitCode, Equals, 0)
+}
+
+func (s *WinRMSuite) TestErrorOnCommand(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
+	count := 0
+	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
+		switch count {
+		case 0:
+			{
+				count = 1
+				return executeCommandResponse, nil
+			}
+		case 1:
+			{
+				count = 2
+				return outputResponse, nil
+			}
+		default:
+			{
+				return doneCommandResponse, nil
+			}
+		}
+	}
+
+	cmd, _ := shell.Execute("ipconfig /all")
+
+	// Test known errors return properly exit codes and message
+	var exitCode int
+	c.Assert(cmd, NotNil)
+
+	cmd.err = fmt.Errorf("Command error")
+	cmd.exitCode = 123
+
+	// Test Message
+	err = client.Error(cmd)
+	c.Assert(err.Error(), Equals, "Command error")
+	// Test ExitCode
+	exitCode = client.ExitCode(cmd)
+	c.Assert(exitCode, Equals, 123)
+
+	// Test command exit code and error are returned even if the client has an error
+	client.err = fmt.Errorf("Test /wsman: EOF")
+	// Test Message
+	err = client.Error(cmd)
+	c.Assert(err.Error(), Equals, "Command error")
+	// Test ExitCode
+	exitCode = client.ExitCode(cmd)
+	c.Assert(exitCode, Equals, 123)
 }

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -77,6 +77,9 @@ func (command *Command) check() (err error) {
 	if command.client == nil {
 		return errors.New("Command has no associated client")
 	}
+	if _, err := command.client.check(); err != nil {
+		return errors.New("WinRM client has an error: " + err.Error())
+	}
 	return
 }
 

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"strings"
 )
 
 type commandWriter struct {
@@ -106,11 +105,6 @@ func (command *Command) slurpAllOutput() (finished bool, err error) {
 
 	response, err := command.client.sendRequest(request)
 	if err != nil {
-		if strings.Contains(err.Error(), "OperationTimeout") {
-			// Operation timeout because there was no command output
-			return
-		}
-
 		command.Stderr.write.CloseWithError(err)
 		command.Stdout.write.CloseWithError(err)
 		return true, err

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -37,7 +37,7 @@ type Command struct {
 }
 
 func newCommand(shell *Shell, commandId string) *Command {
-	command := &Command{shell: shell, client: shell.client, commandId: commandId, exitCode: 1, err: nil, done: make(chan bool)}
+	command := &Command{shell: shell, client: shell.client, commandId: commandId, exitCode: 0, err: nil, done: make(chan bool)}
 	command.Stdin = &commandWriter{Command: command, eof: false}
 	command.Stdout = newCommandReader("stdout", command)
 	command.Stderr = newCommandReader("stderr", command)

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -45,7 +45,7 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 	req.Close = true
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		err = fmt.Errorf("unknown error %s", err)
+		err = fmt.Errorf("error while sending request to endpoint %s", err)
 		return
 	}
 	defer resp.Body.Close()

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -18,7 +18,6 @@ func body(response *http.Response) (content string, err error) {
 	if strings.HasPrefix(contentType, soapXML) {
 		var body []byte
 		body, err = ioutil.ReadAll(response.Body)
-		response.Body.Close()
 		if err != nil {
 			err = fmt.Errorf("error while reading request body %s", err)
 			return
@@ -43,16 +42,16 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 	}
 	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
 	req.SetBasicAuth(client.username, client.password)
+	req.Close = true
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		err = fmt.Errorf("unknown error %s", err)
 		return
 	}
+	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
-		response, err = body(resp)
-	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+	response, err = body(resp)
+	if resp.StatusCode != 200 && err == nil {
 		err = fmt.Errorf("http error: %d - %s", resp.StatusCode, body)
 	}
 

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -37,6 +37,7 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 
 	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
+		client.err = err
 		err = fmt.Errorf("impossible to create http request %s", err)
 		return
 	}
@@ -45,6 +46,7 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 	req.Close = true
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		client.err = err
 		err = fmt.Errorf("error while sending request to endpoint %s", err)
 		return
 	}


### PR DESCRIPTION
PR https://github.com/masterzen/winrm/pull/25 introduced a bug where winrm will exit with error code 1 even when err is empty and a lot of error codes from further on the line are omitted (shell.Close()).
This is affecting remote commands as ```net stop winrm``` or ```Stop-Service winrm``` needed when rebooting a host to ensure winrm does not reconnect too soon on a subsecuent command while rebooting.

This PR is not complete yet, the intention is to get some help on this code as i add to it, since go is not my primary lang.

Reference:
https://github.com/mitchellh/packer/pull/2243
https://github.com/packer-community/packer-windows-plugins/issues/54