### PR TITLE
Fix Makefile so it properly outputs ANSI colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | fgrep -v 'winr
 
 all: deps
 	@mkdir -p bin/
-	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Building$(NO_COLOR)"
 	@go build -o $(GOPATH)/bin/winrm github.com/masterzen/winrm
 
 deps:
-	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -d -v ./...
 	@echo $(DEPS) | xargs -n1 go get -d
 
@@ -24,11 +24,11 @@ format:
 	go fmt ./...
 
 ci: deps
-	@echo "$(OK_COLOR)==> Testing with Coveralls...$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Testing with Coveralls...$(NO_COLOR)"
 	"$(CURDIR)/scripts/test.sh"
 
 test: deps
-	@echo "$(OK_COLOR)==> Testing...$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Testing...$(NO_COLOR)"
 	go test ./...
 
 .PHONY: all clean deps format test updatedeps


### PR DESCRIPTION
As the title says, in some cases (cygwin and MinGW) make was not output the colors properly. I believe this is the case no linux as well, this should take care of it.