### PR TITLE
Set default codepage UTF-8

### DIFF
--- a/development/sample_requests.txt
+++ b/development/sample_requests.txt
@@ -15,7 +15,7 @@
       <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
       <w:OptionSet>
          <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
-         <w:Option Name="WINRS_CODEPAGE">437</w:Option>
+         <w:Option Name="WINRS_CODEPAGE">65001</w:Option>
       </w:OptionSet>
    </env:Header>
    <env:Body>
@@ -140,5 +140,3 @@
       </rsp:Signal>
    </env:Body>
 </env:Envelope>
-
-

--- a/winrm/request.go
+++ b/winrm/request.go
@@ -23,7 +23,7 @@ func NewOpenShellRequest(uri string, params *Parameters) (message *soap.SoapMess
 		params = DefaultParameters()
 	}
 	message = soap.NewMessage()
-	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").AddOption(soap.NewHeaderOption("WINRS_NOPROFILE", "FALSE")).AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "437")).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").AddOption(soap.NewHeaderOption("WINRS_NOPROFILE", "FALSE")).AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "65001")).Build()
 
 	body := message.CreateBodyElement("Shell", soap.NS_WIN_SHELL)
 	input := message.CreateElement(body, "InputStreams", soap.NS_WIN_SHELL)


### PR DESCRIPTION
I'm playing with Windows Nano Servers and it seems that Nano only supports codepage UTF-8.
After changing the codepage from 437 to 65001 I can use this command to communicate with such a Nano Server.

Equivalent change for Ruby https://github.com/WinRb/WinRM/pull/130

More details about Nano Server and having a packer template can be found in this blog post: http://www.hurryupandwait.io/blog/a-packer-template-for-windows-nano-server-weighing-300mb