### PR TITLE
Fix race conditions

### DIFF
--- a/winrm/parameters.go
+++ b/winrm/parameters.go
@@ -1,7 +1,6 @@
 package winrm
 
 type Parameters struct {
-	url          string
 	Timeout      string
 	Locale       string
 	EnvelopeSize int

--- a/winrm/request.go
+++ b/winrm/request.go
@@ -12,9 +12,9 @@ func genUUID() string {
 	return "uuid:" + uuid.String()
 }
 
-func defaultHeaders(message *soap.SoapMessage, params *Parameters) (h *soap.SoapHeader) {
+func defaultHeaders(message *soap.SoapMessage, url string, params *Parameters) (h *soap.SoapHeader) {
 	h = message.Header()
-	h.To(params.url).ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(params.EnvelopeSize).Id(genUUID()).Locale(params.Locale).Timeout(params.Timeout)
+	h.To(url).ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(params.EnvelopeSize).Id(genUUID()).Locale(params.Locale).Timeout(params.Timeout)
 	return
 }
 
@@ -22,9 +22,8 @@ func NewOpenShellRequest(uri string, params *Parameters) (message *soap.SoapMess
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
-	defaultHeaders(message, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").AddOption(soap.NewHeaderOption("WINRS_NOPROFILE", "FALSE")).AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "437")).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").AddOption(soap.NewHeaderOption("WINRS_NOPROFILE", "FALSE")).AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "437")).Build()
 
 	body := message.CreateBodyElement("Shell", soap.NS_WIN_SHELL)
 	input := message.CreateElement(body, "InputStreams", soap.NS_WIN_SHELL)
@@ -38,9 +37,8 @@ func NewDeleteShellRequest(uri string, shellId string, params *Parameters) (mess
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
-	defaultHeaders(message, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete").ShellId(shellId).ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete").ShellId(shellId).ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").Build()
 
 	message.NewBody()
 
@@ -51,9 +49,8 @@ func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, 
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
-	defaultHeaders(message, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).AddOption(soap.NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE")).AddOption(soap.NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).AddOption(soap.NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE")).AddOption(soap.NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).Build()
 	body := message.CreateBodyElement("CommandLine", soap.NS_WIN_SHELL)
 
 	// ensure special characters like & don't mangle the request XML
@@ -74,9 +71,8 @@ func NewGetOutputRequest(uri string, shellId string, commandId string, streams s
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
-	defaultHeaders(message, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
 
 	receive := message.CreateBodyElement("Receive", soap.NS_WIN_SHELL)
 	desiredStreams := message.CreateElement(receive, "DesiredStream", soap.NS_WIN_SHELL)
@@ -89,10 +85,9 @@ func NewSendInputRequest(uri string, shellId string, commandId string, input []b
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
 
-	defaultHeaders(message, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
 
 	content := base64.StdEncoding.EncodeToString(input)
 
@@ -108,10 +103,9 @@ func NewSignalRequest(uri string, shellId string, commandId string, params *Para
 	if params == nil {
 		params = DefaultParameters()
 	}
-	params.url = uri
 	message = soap.NewMessage()
 
-	defaultHeaders(message, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
+	defaultHeaders(message, uri, params).Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId(shellId).Build()
 
 	signal := message.CreateBodyElement("Signal", soap.NS_WIN_SHELL)
 	signal.SetAttr("CommandId", commandId)


### PR DESCRIPTION
With these changes running ```go test -race -v ./...``` results in a clean run of the tests.