### PR TITLE
Add TransportDecorator to the parameter set

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ _Note_: this library doesn't support domain users (it doesn't support GSSAPI nor
 
 
 ## Getting Started
+WinRM is available on Windows Server 2008 and up. This project natively supports basic authentication for local accounts, see the steps in the next section on how to prepare the remote Windows machine for this scenario. The authentication model is pluggable, see below for an example on using Negotiate/NTLM authentication (e.g. for connecting to vanilla Azure VMs).
 
-### Preparing the remote windows machine
-
-WinRM is available on Windows Server 2008 and up. This project supports only basic authentication for local accounts (domain users are not supported).
-The remote windows system must be prepared for winrm:
+### Preparing the remote Windows machine for Basic authentication
+This project supports only basic authentication for local accounts (domain users are not supported). The remote windows system must be prepared for winrm:
 
 _For a PowerShell script to do what is described below in one go, check [Richard Downer's blog](http://www.frontiertown.co.uk/2011/12/overthere-control-windows-from-java/)_
 
@@ -120,6 +119,20 @@ go io.Copy(os.Stderr, cmd.Stderr)
 
 cmd.Wait()
 shell.Close()
+```
+
+### Pluggable authentication example: Negotiate/NTLM authentication
+Using the winrm.Parameters.TransportDecorator, it is possible to wrap or completely replace the outgoing http.RoundTripper. For example, use github.com/paulmey/go-ntlmssp to plug in Negotiate/NTLM authentication :
+
+```go
+import (
+  "github.com/masterzen/winrm/winrm"
+  "github.com/paulmey/go-ntlmssp"
+)
+
+params := winrm.DefaultParameters()
+params.TransportDecorator = func(t *http.Transport) http.RoundTripper { return ntlmssp.Negotiator{t} }
+client, err := winrm.NewClientWithParameters(..., params)
 ```
 
 ## Developing on WinRM

--- a/winrm/client.go
+++ b/winrm/client.go
@@ -18,7 +18,7 @@ type Client struct {
 	useHTTPS  bool
 	url       string
 	http      HttpPost
-	transport *http.Transport
+	transport http.RoundTripper
 }
 
 // NewClient will create a new remote client on url, connecting with user and password
@@ -42,6 +42,10 @@ func NewClientWithParameters(endpoint *Endpoint, user, password string, params *
 		http:       Http_post,
 		useHTTPS:   endpoint.HTTPS,
 		transport:  transport,
+	}
+
+	if params.TransportDecorator != nil {
+		client.transport = params.TransportDecorator(transport)
 	}
 	return
 }

--- a/winrm/client_test.go
+++ b/winrm/client_test.go
@@ -3,6 +3,9 @@ package winrm
 import (
 	"github.com/masterzen/winrm/soap"
 	. "gopkg.in/check.v1"
+	"io/ioutil"
+	"net/http"
+	"strings"
 )
 
 func (s *WinRMSuite) TestNewClient(c *C) {
@@ -24,4 +27,25 @@ func (s *WinRMSuite) TestClientCreateShell(c *C) {
 
 	shell, _ := client.CreateShell()
 	c.Assert(shell.ShellId, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}
+
+func (s *WinRMSuite) TestReplaceTransportWithDecorator(c *C) {
+	var myrt rtfunc = func(req *http.Request) (*http.Response, error) {
+		req.Body.Close()
+		return &http.Response{StatusCode: 500, Body: ioutil.NopCloser(strings.NewReader("yeehaw"))}, nil
+	}
+
+	params := DefaultParameters()
+	params.TransportDecorator = func(*http.Transport) http.RoundTripper { return myrt }
+
+	client, err := NewClientWithParameters(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "password", params)
+	c.Assert(err, IsNil)
+	_, err = client.http(client, soap.NewMessage())
+	c.Assert(err.Error(), Equals, "http error: 500 - yeehaw")
+}
+
+type rtfunc func(*http.Request) (*http.Response, error)
+
+func (f rtfunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/winrm/parameters.go
+++ b/winrm/parameters.go
@@ -1,9 +1,14 @@
 package winrm
 
+import (
+	"net/http"
+)
+
 type Parameters struct {
-	Timeout      string
-	Locale       string
-	EnvelopeSize int
+	Timeout            string
+	Locale             string
+	EnvelopeSize       int
+	TransportDecorator func(*http.Transport) http.RoundTripper
 }
 
 func DefaultParameters() *Parameters {


### PR DESCRIPTION
Allows addition of logic to (or complete replacement of) the http stack