### PR TITLE
Fix #46 add a connect+wait header time out

### DIFF
--- a/winrm.go
+++ b/winrm.go
@@ -39,6 +39,7 @@ func main() {
 		cacert   string
 		gencert  bool
 		certsize string
+		timeout  string
 	)
 
 	flag.StringVar(&hostname, "hostname", "localhost", "winrm host")
@@ -50,6 +51,7 @@ func main() {
 	flag.StringVar(&cacert, "cacert", "", "CA certificate to use")
 	flag.BoolVar(&gencert, "gencert", false, "Generate x509 client certificate to use with secure connections")
 	flag.StringVar(&certsize, "certsize", "", "Priv RSA key between 512, 1024, 2048, 4096. Default :2048")
+	flag.StringVar(&timeout, "timeout", "0s", "connection timeout")
 
 	flag.Parse()
 
@@ -74,8 +76,9 @@ func main() {
 	} else {
 
 		var (
-			certBytes []byte
-			err       error
+			certBytes      []byte
+			err            error
+			connectTimeout time.Duration
 		)
 
 		if cacert != "" {
@@ -87,7 +90,10 @@ func main() {
 
 		cmd = flag.Arg(0)
 
-		endpoint := winrm.NewEndpoint(hostname, port, https, insecure, &certBytes)
+		connectTimeout, err = time.ParseDuration(timeout)
+		check(err)
+
+		endpoint := winrm.NewEndpointWithTimeout(hostname, port, https, insecure, &certBytes, connectTimeout)
 		client, err := winrm.NewClient(endpoint, user, pass)
 		check(err)
 

--- a/winrm/client.go
+++ b/winrm/client.go
@@ -56,6 +56,7 @@ func newTransport(endpoint *Endpoint) (*http.Transport, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint.Insecure,
 		},
+		ResponseHeaderTimeout: endpoint.Timeout,
 	}
 
 	if endpoint.CACert != nil && len(*endpoint.CACert) > 0 {

--- a/winrm/endpoint.go
+++ b/winrm/endpoint.go
@@ -1,6 +1,9 @@
 package winrm
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Endpoint struct holds configurations
 // for the server endpoint
@@ -10,6 +13,7 @@ type Endpoint struct {
 	HTTPS    bool
 	Insecure bool
 	CACert   *[]byte
+	Timeout  time.Duration
 }
 
 func (ep *Endpoint) url() string {
@@ -23,7 +27,7 @@ func (ep *Endpoint) url() string {
 	return fmt.Sprintf("%s://%s:%d/wsman", scheme, ep.Host, ep.Port)
 }
 
-// NewEndpoint returns new pointer to struct Endpoint
+// NewEndpoint returns new pointer to struct Endpoint, with a default 60s response header timeout
 func NewEndpoint(host string, port int, https bool, insecure bool, cert *[]byte) *Endpoint {
 	return &Endpoint{
 		Host:     host,
@@ -31,5 +35,18 @@ func NewEndpoint(host string, port int, https bool, insecure bool, cert *[]byte)
 		HTTPS:    https,
 		Insecure: insecure,
 		CACert:   cert,
+		Timeout:  60 * time.Second,
+	}
+}
+
+// NewEndpointWithTimeout returns a new Endpoint with a defined timeout
+func NewEndpointWithTimeout(host string, port int, https bool, insecure bool, cert *[]byte, timeout time.Duration) *Endpoint {
+	return &Endpoint{
+		Host:     host,
+		Port:     port,
+		HTTPS:    https,
+		Insecure: insecure,
+		CACert:   cert,
+		Timeout:  timeout,
 	}
 }

--- a/winrm/endpoint_test.go
+++ b/winrm/endpoint_test.go
@@ -1,6 +1,8 @@
 package winrm
 
 import (
+	"time"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -12,4 +14,14 @@ func (s *WinRMSuite) TestEndpointUrlHttp(c *C) {
 func (s *WinRMSuite) TestEndpointUrlHttps(c *C) {
 	endpoint := &Endpoint{Host: "abc", Port: 123, HTTPS: true}
 	c.Assert(endpoint.url(), Equals, "https://abc:123/wsman")
+}
+
+func (s *WinRMSuite) TestEndpointWithDefaultTimeout(c *C) {
+	endpoint := NewEndpoint("test", 5585, false, false, nil)
+	c.Assert(endpoint.Timeout, Equals, 60*time.Second)
+}
+
+func (s *WinRMSuite) TestEndpointWithTimeout(c *C) {
+	endpoint := NewEndpointWithTimeout("test", 5585, false, false, nil, 120*time.Second)
+	c.Assert(endpoint.Timeout, Equals, 120*time.Second)
 }


### PR DESCRIPTION
When the windows firewall is on, and winrm is not blocked, the connection
will be accepted but no response will be sent by the winrm server.
In this case, the winrm client will wait almost indefinitely.
This prevents packer from being able to detect when winrm is ready on
a prepared VM.
The default timeout is 60s (which should be enough for running a command
on a winrm enabled host), but still not too much so that Packer doesn't
wait too long.
The timeout is overridable (check -timeout for the winrm command, or through
the Endpoint mechanism with NewEndpointWithTimeout).

Of course this requires changes in Packer if one wants to be able to modify the timeout.

Do any of @dylanmei , @pecigonzalo, @mefellows , @boumenot (or anyone else) wants to take care of adding the timeout on the Packer side?
