### PR TITLE
Fix #48 - OperationTimeout aborts the current command

### DIFF
--- a/winrm/client.go
+++ b/winrm/client.go
@@ -115,17 +115,17 @@ func (client *Client) sendRequest(request *soap.SoapMessage) (response string, e
 func (client *Client) Run(command string, stdout io.Writer, stderr io.Writer) (exitCode int, err error) {
 	shell, err := client.CreateShell()
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
+	defer shell.Close()
 	var cmd *Command
 	cmd, err = shell.Execute(command)
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 	go io.Copy(stdout, cmd.Stdout)
 	go io.Copy(stderr, cmd.Stderr)
 	cmd.Wait()
-	shell.Close()
 	return cmd.ExitCode(), cmd.err
 }
 
@@ -134,13 +134,13 @@ func (client *Client) Run(command string, stdout io.Writer, stderr io.Writer) (e
 func (client *Client) RunWithString(command string, stdin string) (stdout string, stderr string, exitCode int, err error) {
 	shell, err := client.CreateShell()
 	if err != nil {
-		return "", "", 0, err
+		return "", "", 1, err
 	}
 	defer shell.Close()
 	var cmd *Command
 	cmd, err = shell.Execute(command)
 	if err != nil {
-		return "", "", 0, err
+		return "", "", 1, err
 	}
 	if len(stdin) > 0 {
 		cmd.Stdin.Write([]byte(stdin))
@@ -160,13 +160,13 @@ func (client *Client) RunWithString(command string, stdin string) (stdout string
 func (client *Client) RunWithInput(command string, stdout io.Writer, stderr io.Writer, stdin io.Reader) (exitCode int, err error) {
 	shell, err := client.CreateShell()
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 	defer shell.Close()
 	var cmd *Command
 	cmd, err = shell.Execute(command)
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 	go io.Copy(cmd.Stdin, stdin)
 	go io.Copy(stdout, cmd.Stdout)

--- a/winrm/client_test.go
+++ b/winrm/client_test.go
@@ -33,7 +33,8 @@ func (s *WinRMSuite) TestClientCreateShell(c *C) {
 func (s *WinRMSuite) TestReplaceTransportWithDecorator(c *C) {
 	var myrt rtfunc = func(req *http.Request) (*http.Response, error) {
 		req.Body.Close()
-		return &http.Response{StatusCode: 500, Body: ioutil.NopCloser(strings.NewReader(""))}, nil
+		header := http.Header{"Content-Type": {"application/soap+xml; charset=UTF-8"}}
+		return &http.Response{StatusCode: 500, Header: header, Body: ioutil.NopCloser(strings.NewReader(""))}, nil
 	}
 
 	params := DefaultParameters
@@ -42,7 +43,7 @@ func (s *WinRMSuite) TestReplaceTransportWithDecorator(c *C) {
 	client, err := NewClientWithParameters(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "password", params)
 	c.Assert(err, IsNil)
 	_, err = client.http(client, soap.NewMessage())
-	c.Assert(err.Error(), Equals, "http error: 500")
+	c.Assert(err.Error(), Equals, "http error: 500 - ")
 }
 
 type rtfunc func(*http.Request) (*http.Response, error)

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -42,7 +42,7 @@ func newCommand(shell *Shell, id string) *Command {
 		shell:    shell,
 		client:   shell.client,
 		ID:       id,
-		exitCode: 1,
+		exitCode: 0,
 		err:      nil,
 		done:     make(chan struct{}),
 		cancel:   make(chan struct{}),

--- a/winrm/command.go
+++ b/winrm/command.go
@@ -135,6 +135,9 @@ func (command *Command) slurpAllOutput() (finished bool, err error) {
 			// Operation timeout because there was no command output
 			return
 		}
+		if strings.Contains(err.Error(), "EOF") {
+			command.exitCode = 16001
+		}
 
 		command.Stderr.write.CloseWithError(err)
 		command.Stdout.write.CloseWithError(err)

--- a/winrm/command_test.go
+++ b/winrm/command_test.go
@@ -5,11 +5,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -181,7 +178,7 @@ func (s *WinRMSuite) TestCloseCommandStopsFetch(c *C) {
 
 func (s *WinRMSuite) TestConnectionTimeout(c *C) {
 	count := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)
 		w.Header().Set("Content-Type", "application/soap+xml")
 		switch count {
@@ -203,24 +200,105 @@ func (s *WinRMSuite) TestConnectionTimeout(c *C) {
 	}))
 	defer ts.Close()
 
-	// find port
-	url, err := url.Parse(ts.URL)
-	if err != nil {
-		c.Error(err)
-	}
-	host, port, err := net.SplitHostPort(url.Host)
-	if err != nil {
-		c.Error(err)
-	}
-	iport, err := strconv.Atoi(port)
 	if err != nil {
 		c.Error(err)
 	}
 
-	client, err := NewClient(&Endpoint{Host: host, Port: iport, Timeout: 1 * time.Second}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: host, Port: port, Timeout: 1 * time.Second}, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ID: "67A74734-DD32-4F10-89DE-49A060483810"}
 	_, err = shell.Execute("ipconfig /all")
 	c.Assert(err, ErrorMatches, ".*timeout.*")
+}
+
+func (s *WinRMSuite) TestOperationTimeoutSupport(c *C) {
+	count := 0
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		switch count {
+		case 0:
+			{
+				count = 1
+				fmt.Fprintln(w, executeCommandResponse)
+			}
+		case 1:
+			{
+				count = 2
+				w.WriteHeader(500)
+				fmt.Fprintln(w, operationTimeoutResponse)
+			}
+		case 2:
+			{
+				count = 3
+				fmt.Fprintln(w, outputResponse)
+			}
+		default:
+			{
+				fmt.Fprintln(w, doneCommandResponse)
+			}
+		}
+	}))
+	defer ts.Close()
+
+	if err != nil {
+		c.Error(err)
+	}
+
+	client, err := NewClient(&Endpoint{Host: host, Port: port}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ID: "67A74734-DD32-4F10-89DE-49A060483810"}
+	command, _ := shell.Execute("ipconfig /all")
+	var stdout, stderr bytes.Buffer
+	var wg sync.WaitGroup
+	f := func(b *bytes.Buffer, r *commandReader) {
+		wg.Add(1)
+		defer wg.Done()
+		io.Copy(b, r)
+	}
+	go f(&stdout, command.Stdout)
+	go f(&stderr, command.Stderr)
+	command.Wait()
+	wg.Wait()
+	c.Assert(stdout.String(), Equals, "That's all folks!!!")
+	c.Assert(stderr.String(), Equals, "This is stderr, I'm pretty sure!")
+}
+
+func (s *WinRMSuite) TestEOFError(c *C) {
+	count := 0
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		switch count {
+		case 0:
+			{
+				count = 1
+				fmt.Fprintln(w, executeCommandResponse)
+			}
+		case 1:
+			{
+				ts.CloseClientConnections()
+			}
+		default:
+			{
+				fmt.Fprintln(w, doneCommandResponse)
+			}
+		}
+	}))
+
+	host, port, err := FindHostAndPortFromURL(ts.URL)
+	if err != nil {
+		c.Error(err)
+	}
+
+	client, err := NewClient(&Endpoint{Host: host, Port: port}, "Administrator", "v3r1S3cre7")
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ID: "67A74734-DD32-4F10-89DE-49A060483810"}
+	command, _ := shell.Execute("ipconfig /all")
+	ts.CloseClientConnections()
+	command.Wait()
+	c.Assert(command.exitCode, Equals, 16001)
+	c.Assert(command.err.Error(), Contains, "EOF")
 }

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -47,10 +47,10 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 		return "", fmt.Errorf("unknown error %s", err)
 	}
 
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("http error: %d", resp.StatusCode)
+	body, err := body(resp)
+	if resp.StatusCode != 200 && err != nil {
+		return "", fmt.Errorf("http error: %d - %s", resp.StatusCode, body)
 	}
 
-	return body(resp)
-
+	return body, err
 }

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -32,13 +32,12 @@ func body(response *http.Response) (string, error) {
 }
 
 // Http_post make post to the winrm soap service
-func Http_post(client *Client, request *soap.SoapMessage) (response string, err error) {
+func Http_post(client *Client, request *soap.SoapMessage) (string, error) {
 	httpClient := &http.Client{Transport: client.transport}
 
 	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
-		err = fmt.Errorf("impossible to create http request %s", err)
-		return
+		return "", fmt.Errorf("impossible to create http request %s", err)
 	}
 	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
 	req.SetBasicAuth(client.username, client.password)
@@ -48,7 +47,10 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 	}
 
 	body, err := body(resp)
-	if resp.StatusCode != 200 && err != nil {
+	if err != nil {
+		return "", fmt.Errorf("http response error: %d - %s", resp.StatusCode, err.Error())
+	}
+	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("http error: %d - %s", resp.StatusCode, body)
 	}
 


### PR DESCRIPTION
Since PR #25 winrm is now unfortunately reporting up `OperationTimeout` errors when the command doesn't output anything, and aborting processing.

This changeset is PR #26 by @pecigonzalo which I rebased in order to be able to merge it on top of current master.
 