### PR TITLE
Increase test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | fgrep -v 'winr
 
 all: deps
 	@mkdir -p bin/
-	@echo -e "$(OK_COLOR)==> Building$(NO_COLOR)"
+	@printf "$(OK_COLOR)==> Building$(NO_COLOR)\n"
 	@go build -o $(GOPATH)/bin/winrm github.com/masterzen/winrm
 
 deps:
-	@echo -e "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
+	@printf "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)\n"
 	@go get -d -v ./...
 	@echo $(DEPS) | xargs -n1 go get -d
 
@@ -24,11 +24,11 @@ format:
 	go fmt ./...
 
 ci: deps
-	@echo -e "$(OK_COLOR)==> Testing with Coveralls...$(NO_COLOR)"
+	@printf "$(OK_COLOR)==> Testing with Coveralls...$(NO_COLOR)\n"
 	"$(CURDIR)/scripts/test.sh"
 
 test: deps
-	@echo -e "$(OK_COLOR)==> Testing...$(NO_COLOR)"
+	@printf "$(OK_COLOR)==> Testing...$(NO_COLOR)\n"
 	go test ./...
 
 .PHONY: all clean deps format test updatedeps

--- a/soap/header_test.go
+++ b/soap/header_test.go
@@ -13,6 +13,12 @@ type MySuite struct{}
 
 var _ = Suite(&MySuite{})
 
+func (s *MySuite) TestNewHeader(c *C) {
+	ho := NewHeaderOption("WINRS_CODEPAGE", "65001")
+	c.Assert(ho.key, Equals, "WINRS_CODEPAGE")
+	c.Assert(ho.value, Equals, "65001")
+}
+
 func initDocument() (h *SoapHeader) {
 	doc := dom.CreateDocument()
 	doc.PrettyPrint = true
@@ -26,7 +32,8 @@ func initDocument() (h *SoapHeader) {
 
 func (s *MySuite) TestHeaderBuild(c *C) {
 	h := initDocument()
-	msg := h.To("http://winrm:5985/wsman").ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").Build()
+	msg := h.To("http://winrm:5985/wsman").ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").
+		Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").Build()
 
 	expected := `<?xml version="1.0" encoding="utf-8" ?>
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
@@ -40,6 +47,101 @@ func (s *MySuite) TestHeaderBuild(c *C) {
     <a:MessageID>1-2-3-4</a:MessageID>
     <w:Locale mustUnderstand="false" xml:lang="en_US"/>
     <p:DataLocale mustUnderstand="false" xml:lang="en_US"/>
+    <a:Action mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</a:Action>
+  </env:Header>
+</env:Envelope>
+`
+
+	c.Check(msg.String(), Equals, expected)
+}
+
+func (s *MySuite) TestOtherHeaderBuild(c *C) {
+	h := initDocument()
+	msg := h.To("http://winrm:5985/wsman").ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete").ShellId("shell-id").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").Build()
+
+	expected := `<?xml version="1.0" encoding="utf-8" ?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+  <env:Header>
+    <a:To>http://winrm:5985/wsman</a:To>
+    <a:ReplyTo>
+      <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+    </a:ReplyTo>
+    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+    <w:OperationTimeout>PT60S</w:OperationTimeout>
+    <a:MessageID>1-2-3-4</a:MessageID>
+    <w:Locale mustUnderstand="false" xml:lang="en_US"/>
+    <p:DataLocale mustUnderstand="false" xml:lang="en_US"/>
+    <a:Action mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</a:Action>
+    <w:SelectorSet>
+      <w:Selector Name="ShellId">shell-id</w:Selector>
+    </w:SelectorSet>
+    <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+  </env:Header>
+</env:Envelope>
+`
+
+	c.Check(msg.String(), Equals, expected)
+}
+
+func (s *MySuite) TestAddOptionHeaderBuild(c *C) {
+	h := initDocument()
+	msg := h.To("http://winrm:5985/wsman").ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId("shell-id").AddOption(NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE")).AddOption(NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).Build()
+
+	expected := `<?xml version="1.0" encoding="utf-8" ?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+  <env:Header>
+    <a:To>http://winrm:5985/wsman</a:To>
+    <a:ReplyTo>
+      <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+    </a:ReplyTo>
+    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+    <w:OperationTimeout>PT60S</w:OperationTimeout>
+    <a:MessageID>1-2-3-4</a:MessageID>
+    <w:Locale mustUnderstand="false" xml:lang="en_US"/>
+    <p:DataLocale mustUnderstand="false" xml:lang="en_US"/>
+    <a:Action mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</a:Action>
+    <w:SelectorSet>
+      <w:Selector Name="ShellId">shell-id</w:Selector>
+    </w:SelectorSet>
+    <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+    <w:OptionSet>
+      <w:Option Name="WINRS_CONSOLEMODE_STDIN">TRUE</w:Option>
+      <w:Option Name="WINRS_SKIP_CMD_SHELL">FALSE</w:Option>
+    </w:OptionSet>
+  </env:Header>
+</env:Envelope>
+`
+
+	c.Check(msg.String(), Equals, expected)
+}
+
+func (s *MySuite) TestOptionsHeaderBuild(c *C) {
+	h := initDocument()
+	msg := h.To("http://winrm:5985/wsman").ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").
+		Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").ShellId("shell-id").
+		Options([]HeaderOption{*NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE"), *NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")}).Build()
+
+	expected := `<?xml version="1.0" encoding="utf-8" ?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+  <env:Header>
+    <a:To>http://winrm:5985/wsman</a:To>
+    <a:ReplyTo>
+      <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+    </a:ReplyTo>
+    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+    <w:OperationTimeout>PT60S</w:OperationTimeout>
+    <a:MessageID>1-2-3-4</a:MessageID>
+    <w:Locale mustUnderstand="false" xml:lang="en_US"/>
+    <p:DataLocale mustUnderstand="false" xml:lang="en_US"/>
+    <a:Action mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</a:Action>
+    <w:SelectorSet>
+      <w:Selector Name="ShellId">shell-id</w:Selector>
+    </w:SelectorSet>
+    <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+    <w:OptionSet>
+      <w:Option Name="WINRS_CONSOLEMODE_STDIN">TRUE</w:Option>
+      <w:Option Name="WINRS_SKIP_CMD_SHELL">FALSE</w:Option>
+    </w:OptionSet>
   </env:Header>
 </env:Envelope>
 `

--- a/soap/message_test.go
+++ b/soap/message_test.go
@@ -1,0 +1,55 @@
+package soap
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestNewMessage(c *C) {
+	message := NewMessage()
+	defer message.Free()
+	message.Doc().PrettyPrint = true
+	message.Header().To("http://winrm:5985/wsman").
+		ReplyTo("http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous").
+		MaxEnvelopeSize(153600).Id("1-2-3-4").Locale("en_US").Timeout("PT60S").
+		Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Create").
+		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
+		AddOption(NewHeaderOption("WINRS_NOPROFILE", "FALSE")).
+		AddOption(NewHeaderOption("WINRS_CODEPAGE", "65001")).
+		Build()
+
+	body := message.CreateBodyElement("Shell", NS_WIN_SHELL)
+	input := message.CreateElement(body, "InputStreams", NS_WIN_SHELL)
+	input.SetContent("stdin")
+	output := message.CreateElement(body, "OutputStreams", NS_WIN_SHELL)
+	output.SetContent("stdout stderr")
+
+	expected := `<?xml version="1.0" encoding="utf-8" ?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+  <env:Header>
+    <a:To>http://winrm:5985/wsman</a:To>
+    <a:ReplyTo>
+      <a:Address mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>
+    </a:ReplyTo>
+    <w:MaxEnvelopeSize mustUnderstand="true">153600</w:MaxEnvelopeSize>
+    <w:OperationTimeout>PT60S</w:OperationTimeout>
+    <a:MessageID>1-2-3-4</a:MessageID>
+    <w:Locale mustUnderstand="false" xml:lang="en_US"/>
+    <p:DataLocale mustUnderstand="false" xml:lang="en_US"/>
+    <a:Action mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</a:Action>
+    <w:ResourceURI mustUnderstand="true">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+    <w:OptionSet>
+      <w:Option Name="WINRS_NOPROFILE">FALSE</w:Option>
+      <w:Option Name="WINRS_CODEPAGE">65001</w:Option>
+    </w:OptionSet>
+  </env:Header>
+  <env:Body>
+    <rsp:Shell>
+      <rsp:InputStreams>stdin</rsp:InputStreams>
+      <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+    </rsp:Shell>
+  </env:Body>
+</env:Envelope>
+`
+
+	c.Check(message.String(), Equals, expected)
+}

--- a/soap/namespaces_test.go
+++ b/soap/namespaces_test.go
@@ -19,7 +19,7 @@ func TestAddUsualNamespaces(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("Test failed - Namespace %s not found", ns)
+			t.Errorf("Test failed - Namespace %v not found", ns)
 		}
 	}
 

--- a/winrm/http_test.go
+++ b/winrm/http_test.go
@@ -1,9 +1,7 @@
 package winrm
 
 import (
-	"net"
 	"net/http"
-	"net/http/httptest"
 
 	. "gopkg.in/check.v1"
 )
@@ -41,18 +39,13 @@ stderr</rsp:OutputStreams>
 </s:Envelope>`
 
 func (s *WinRMSuite) TestHttpRequest(c *C) {
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/soap+xml")
 		w.Write([]byte(response))
 	}))
-	l, err := net.Listen("tcp", "127.0.0.1:15985")
-	if err != nil {
-		c.Fatalf("Can't listen %s", err)
-	}
-	ts.Listener = l
-	ts.Start()
+    c.Assert(err, IsNil)
 	defer ts.Close()
-	endpoint := NewEndpoint("localhost", 15985, false, false, nil)
+	endpoint := NewEndpoint(host, port, false, false, nil)
 	client, err := NewClient(endpoint, "test", "test")
 	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()


### PR DESCRIPTION
This improves globally the test coverage, especially:
* soap headers and messages building
* end-to-end client function `Run`, `RunWithString` and `RunWithInput`
