### PR TITLE
(#60) Use my own fork of azure-sdk-for-go

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/core/http"
-	"github.com/Azure/azure-sdk-for-go/core/tls"
+	"github.com/masterzen/azure-sdk-for-go/core/http"
+	"github.com/masterzen/azure-sdk-for-go/core/tls"
 
 	"github.com/masterzen/winrm/soap"
 )


### PR DESCRIPTION
Azure removed their fork of http/tls because this is now part of Go 1.7
Since we still want to be compatible with Go 1.6, we're now depending
of a fork of Azure/azure-sdk-for-go that still contain the http/tls fork.

This will be removed once we'll support Go1.7