### PR TITLE
proposal to add support for NTLMv2 via Microsofts go-ntlmssp

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ if err != nil {
 
 ```
 
+By passing a TransportDecorator in the Parameters struct it is possible to use different Transports (e.g. NTLM)
+
+```go
+package main
+import (
+  "github.com/masterzen/winrm"
+  "fmt"
+  "os"
+)
+
+endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+
+params := DefaultParameters
+params.TransportDecorator = func() Transporter { return &ClientNTLM{} }
+
+client, err := NewClientWithParameters(endpoint, "test", "test", params)
+if err != nil {
+	panic(err)
+}
+
+_, err := client.RunWithInput("ipconfig", os.Stdout, os.Stderr, os.Stdin)
+if err != nil {
+	panic(err)
+}
+
+```
+
 For a more complex example, it is possible to call the various functions directly:
 
 ```go
@@ -185,7 +212,7 @@ and [Bazaar](http://bazaar.canonical.com/en/) to be installed.
 Winrm itself doesn't require these, but a dependency of a dependency does.
 
 Next, clone this repository into `$GOPATH/src/github.com/masterzen/winrm` and
-then just type `make`. 
+then just type `make`.
 
 You can run tests by typing `make test`.
 

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,0 +1,23 @@
+package winrm
+
+import (
+	ntlmssp "github.com/Azure/go-ntlmssp"
+	"github.com/masterzen/winrm/soap"
+)
+
+// ClientNTLM provides a transport via NTLMv2
+type ClientNTLM struct {
+	clientRequest
+}
+
+// Transport creates the wrapped NTLM transport
+func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
+	c.clientRequest.Transport(endpoint)
+	c.clientRequest.transport = &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
+	return nil
+}
+
+// Post make post to the winrm soap service (forwarded to clientRequest implementation)
+func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
+	return c.clientRequest.Post(client, request)
+}

--- a/ntlm_test.go
+++ b/ntlm_test.go
@@ -1,0 +1,26 @@
+package winrm
+
+import (
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *WinRMSuite) TestHttpNTLMRequest(c *C) {
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.Write([]byte(response))
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+
+	params := DefaultParameters
+	params.TransportDecorator = func() Transporter { return &ClientNTLM{} }
+	client, err := NewClientWithParameters(endpoint, "test", "test", params)
+
+	c.Assert(err, IsNil)
+	shell, err := client.CreateShell()
+	c.Assert(err, IsNil)
+	c.Assert(shell.id, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}


### PR DESCRIPTION
Currently the Azure builder in mitchellh/packer is based on winrm. Unfortunately the change from
`TransportDecorator func(*http.Transport) http.RoundTripper`
to 
`TransportDecorator func() Transporter`
broke packers Azure builder implementation that uses NTLM. Since the basic HTTP implementation (`type clientRequest struct{...}`) is private to winrm I propose to move it here.