### PR TITLE
default transport: proxy from environment

### DIFF
--- a/http.go
+++ b/http.go
@@ -41,6 +41,7 @@ type clientRequest struct {
 
 func (c *clientRequest) Transport(endpoint *Endpoint) error {
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint.Insecure,
 		},


### PR DESCRIPTION
This will make winrm work with proxies out of the box.

There was an issue requesting this at mitchellh/packer#4418

While we could make our own transport, there's so much config logic in `clientRequest.Transport` that I think it makes more sense to modify it upstream. Otherwise I'd worry about getting out of sync.