### PR TITLE
Set KeepAlive and dial timeout to defaults

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,7 +3,9 @@ package winrm
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strings"
+	"time"
 
 	"github.com/masterzen/azure-sdk-for-go/core/http"
 	"github.com/masterzen/azure-sdk-for-go/core/tls"
@@ -26,6 +28,10 @@ func (c *ClientAuthRequest) Transport(endpoint *Endpoint) error {
 			InsecureSkipVerify: endpoint.Insecure,
 			Certificates:       []tls.Certificate{cert},
 		},
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 		ResponseHeaderTimeout: endpoint.Timeout,
 	}
 

--- a/http.go
+++ b/http.go
@@ -4,8 +4,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/masterzen/winrm/soap"
 )
@@ -46,6 +48,10 @@ func (c *clientRequest) Transport(endpoint *Endpoint) error {
 			InsecureSkipVerify: endpoint.Insecure,
 			ServerName:         endpoint.TLSServerName,
 		},
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 		ResponseHeaderTimeout: endpoint.Timeout,
 	}
 


### PR DESCRIPTION
Needed to fix an issue reported at https://github.com/hashicorp/packer/issues/4848 where connections with long periods of inactivity would be dropped. This patch has been tested by a user on that thread and shown to work