### PR TITLE
Fix #77 - fix RunWithString race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: go
 go:
 - 1.5
 - 1.6
-- tip
+- 1.7
+- 1.8
+- 1.9
+- '1.10'
 install:
 - make deps
 - go build -o winrm-cli


### PR DESCRIPTION
This doesn't happen with Go < 1.10, but there was a race condition in
`RunWithString` and `RunWithInput` which had already been fixed in `Run`.
It was possible for the function to return while the `stdout` or `stderr`
copy was still in progress. Since `bytes.Buffer` is not thread safe, the
`outwriter.String()` could see an intermediate buffer state while it
was growing, leading to strange results.