### PR TITLE
Exposing http client for govcr

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -20,7 +20,7 @@ func (r Requester) Post(client *Client, request *soap.SoapMessage) (string, erro
 	return r.http(client, request)
 }
 
-func (r Requester) Transport(endpoint *Endpoint) error {
+func (r Requester) Transport(endpoint *Endpoint) (http.RoundTripper, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint.Insecure,
@@ -31,15 +31,14 @@ func (r Requester) Transport(endpoint *Endpoint) error {
 	if endpoint.CACert != nil && len(endpoint.CACert) > 0 {
 		certPool, err := readCACerts(endpoint.CACert)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		transport.TLSClientConfig.RootCAs = certPool
 	}
 
 	r.transport = transport
-
-	return nil
+	return transport, nil
 
 }
 

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,6 +1,8 @@
 package winrm
 
 import (
+	"net/http"
+
 	"github.com/Azure/go-ntlmssp"
 	"github.com/masterzen/winrm/soap"
 )
@@ -11,10 +13,11 @@ type ClientNTLM struct {
 }
 
 // Transport creates the wrapped NTLM transport
-func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
+func (c *ClientNTLM) Transport(endpoint *Endpoint) (http.RoundTripper, error) {
 	c.clientRequest.Transport(endpoint)
-	c.clientRequest.transport = &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
-	return nil
+	transport := &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
+	c.clientRequest.transport = transport
+	return transport, nil
 }
 
 // Post make post to the winrm soap service (forwarded to clientRequest implementation)


### PR DESCRIPTION
Hi,

This lib is working nicely for me at the moment.  One small improvement I'd like to make is to expose the httpClient pointer within your client struct.  The main reason is that I want to use the [govcr library](https://github.com/seborama/govcr) within my tests.

Happy to take any comments and refactor as you see fit to achieve this goal.

Best Regards,
Mike