### PR TITLE
Close stdin stream after sending all data

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,6 +149,7 @@ func (c *Client) RunWithString(command string, stdin string) (string, string, in
 	}
 	if len(stdin) > 0 {
 		cmd.Stdin.Write([]byte(stdin))
+		cmd.Stdin.Close()
 	}
 
 	var outWriter, errWriter bytes.Buffer
@@ -192,6 +193,7 @@ func (c Client) RunWithInput(command string, stdout, stderr io.Writer, stdin io.
 	go func() {
 		defer wg.Done()
 		io.Copy(cmd.Stdin, stdin)
+		cmd.Stdin.Close()
 	}()
 	go func() {
 		defer wg.Done()

--- a/command.go
+++ b/command.go
@@ -225,8 +225,11 @@ func min(a int, b int) int {
 // Close method wrapper
 // commandWriter implements io.Closer interface
 func (w *commandWriter) Close() error {
+	if w.eof {
+		return errors.New("commandWriter already closed")
+	}
 	w.eof = true
-	return w.Close()
+	return w.sendInput(nil)
 }
 
 // Read data from this Pipe

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -145,6 +145,11 @@ func runWinRMFakeServer(c *C, expectedStdin string) (*httptest.Server, string, i
 			stdins, err := xPath(doc, "//rsp:Stream[@Name='stdin']")
 			c.Assert(err, IsNil)
 			for _, node := range stdins {
+				end, err := any(node, "//[@End='true']")
+				c.Assert(err, IsNil)
+				if end {
+					expectedStdin = ""
+				}
 				content, _ := base64.StdEncoding.DecodeString(node.ResValue())
 				stdin.Write(content)
 			}

--- a/request.go
+++ b/request.go
@@ -130,6 +130,9 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, params *P
 	streams := message.CreateElement(send, "Stream", soap.DOM_NS_WIN_SHELL)
 	streams.SetAttr("Name", "stdin")
 	streams.SetAttr("CommandId", commandId)
+	if len(input) == 0 {
+		streams.SetAttr("End", "true")
+	}
 	streams.SetContent(content)
 	return message
 }


### PR DESCRIPTION
RunWithInput and RunWithString do not signal the end of the stdin
stream.  This can cause remote commands to hang after consuming all data
from standard input if they block waiting for standard input to be
closed.

Fix this by sending an additional rsp:Stream block with no data and an
End="true" attribute after all stdin data has been sent.  The End
attribute is specified in section 3.7.5 of "Remote Shell Web Services
Protocol" (http://xml.coverpages.org/MS-RemoteShell-200607.pdf).