### PR TITLE
Add support for custom dialers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,44 @@ if err != nil {
 
 ```
 
+By passing a Dial in the Parameters struct it is possible to use different dialer (e.g. tunnel through SSH)
+
+```go
+package main
+     
+ import (
+    "github.com/masterzen/winrm"
+    "golang.org/x/crypto/ssh"
+    "os"
+ )
+ 
+ func main() {
+ 
+    sshClient, err := ssh.Dial("tcp","localhost:22", &ssh.ClientConfig{
+        User:"ubuntu",
+        Auth: []ssh.AuthMethod{ssh.Password("ubuntu")},
+        HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+    })
+ 
+    endpoint := winrm.NewEndpoint("other-host", 5985, false, false, nil, nil, nil, 0)
+ 
+    params := winrm.DefaultParameters
+    params.Dial = sshClient.Dial
+ 
+    client, err := winrm.NewClientWithParameters(endpoint, "test", "test", params)
+    if err != nil {
+        panic(err)
+    }
+ 
+    _, err = client.RunWithInput("ipconfig", os.Stdout, os.Stderr, os.Stdin)
+    if err != nil {
+        panic(err)
+    }
+ }
+
+```
+
+
 For a more complex example, it is possible to call the various functions directly:
 
 ```go

--- a/client.go
+++ b/client.go
@@ -46,7 +46,7 @@ func NewClientWithParameters(endpoint *Endpoint, user, password string, params *
 		url:        endpoint.url(),
 		useHTTPS:   endpoint.HTTPS,
 		// default transport
-		http: &clientRequest{},
+		http: &clientRequest{ dial:params.Dial },
 	}
 
 	// switch to other transport if provided

--- a/http.go
+++ b/http.go
@@ -39,19 +39,27 @@ func body(response *http.Response) (string, error) {
 
 type clientRequest struct {
 	transport http.RoundTripper
+	dial func(network, addr string) (net.Conn, error)
 }
 
 func (c *clientRequest) Transport(endpoint *Endpoint) error {
+
+	dial := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial
+
+	if c.dial != nil {
+		dial = c.dial
+	}
+
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint.Insecure,
 			ServerName:         endpoint.TLSServerName,
 		},
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
+		Dial: dial,
 		ResponseHeaderTimeout: endpoint.Timeout,
 	}
 
@@ -98,4 +106,11 @@ func (c clientRequest) Post(client *Client, request *soap.SoapMessage) (string, 
 	}()
 
 	return body, err
+}
+
+
+func NewClientWithDial(dial func(network, addr string) (net.Conn, error)) *clientRequest {
+	return &clientRequest{
+		dial:dial,
+	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	. "gopkg.in/check.v1"
+	"net"
+	"time"
 )
 
 var response = `<s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
@@ -51,4 +53,32 @@ func (s *WinRMSuite) TestHttpRequest(c *C) {
 	shell, err := client.CreateShell()
 	c.Assert(err, IsNil)
 	c.Assert(shell.id, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}
+
+
+func (s *WinRMSuite) TestHttpViaCustomDialerRequest(c *C) {
+	normalDialer := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial
+	usedCustomDialer := false
+	dial := func(network, addr string) (net.Conn, error) {
+		usedCustomDialer = true
+		return normalDialer(network, addr)
+	}
+
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.Write([]byte(response))
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+	params := DefaultParameters
+	params.TransportDecorator = func() Transporter { return NewClientWithDial(dial) }
+	client, err := NewClientWithParameters(endpoint, "test", "test", params)
+	c.Assert(err, IsNil)
+	_, err = client.CreateShell()
+	c.Assert(err, IsNil)
+	c.Assert(usedCustomDialer, Equals, true)
 }

--- a/ntlm.go
+++ b/ntlm.go
@@ -3,6 +3,7 @@ package winrm
 import (
 	"github.com/Azure/go-ntlmssp"
 	"github.com/masterzen/winrm/soap"
+	"net"
 )
 
 // ClientNTLM provides a transport via NTLMv2
@@ -20,4 +21,13 @@ func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
 // Post make post to the winrm soap service (forwarded to clientRequest implementation)
 func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
 	return c.clientRequest.Post(client, request)
+}
+
+
+func NewClientNTLMWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
+	return &ClientNTLM{
+		clientRequest{
+			dial:dial,
+		},
+	}
 }

--- a/ntlm_test.go
+++ b/ntlm_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	. "gopkg.in/check.v1"
+	"net"
+	"time"
 )
 
 func (s *WinRMSuite) TestHttpNTLMRequest(c *C) {
@@ -24,3 +26,34 @@ func (s *WinRMSuite) TestHttpNTLMRequest(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(shell.id, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
 }
+
+
+func (s *WinRMSuite) TestHttpNTLMViaCustomDialerRequest(c *C) {
+
+	normalDialer := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial
+	usedCustomDialer := false
+	dial := func(network, addr string) (net.Conn, error) {
+		usedCustomDialer = true
+		return normalDialer(network, addr)
+	}
+
+	ts, host, port, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.Write([]byte(response))
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+	endpoint := NewEndpoint(host, port, false, false, nil, nil, nil, 0)
+
+	params := DefaultParameters
+	params.TransportDecorator = func() Transporter { return NewClientNTLMWithDial(dial) }
+	client, err := NewClientWithParameters(endpoint, "test", "test", params)
+	c.Assert(err, IsNil)
+	_, err = client.CreateShell()
+	c.Assert(err, IsNil)
+	c.Assert(usedCustomDialer, Equals, true)
+}
+

--- a/parameters.go
+++ b/parameters.go
@@ -1,5 +1,7 @@
 package winrm
 
+import "net"
+
 // Parameters struct defines
 // metadata information and http transport config
 type Parameters struct {
@@ -7,6 +9,7 @@ type Parameters struct {
 	Locale             string
 	EnvelopeSize       int
 	TransportDecorator func() Transporter
+	Dial               func(network, addr string) (net.Conn, error)
 }
 
 // DefaultParameters return constant config


### PR DESCRIPTION
This allows to e.g. easily tunnel WinRM connection via SSH to connect
to hosts in a private subnet with access only through a jump host.

The context of this change is to allow tunneling WinRM via SSH bastion host in terraform provisioners

The PR introduces a breaking change to the API so if you see a better way to introduce support for custom dialers, I'm more than happy to change the code.