### PR TITLE
Encode the command string as a Windows wide-character string (UTF-16LE)

### DIFF
--- a/powershell.go
+++ b/powershell.go
@@ -3,21 +3,28 @@ package winrm
 import (
 	"encoding/base64"
 	"fmt"
+	"unicode/utf16"
 )
 
 // Powershell wraps a PowerShell script
 // and prepares it for execution by the winrm client
 func Powershell(psCmd string) string {
-	// 2 byte chars to make PowerShell happy
-	wideCmd := ""
-	for _, b := range []byte(psCmd) {
-		wideCmd += string(b) + "\x00"
-	}
+	// Encode the command string as a Windows wide-character string (UTF-16LE).
+	wideCmd := encodeUtf16Le(psCmd)
 
 	// Base64 encode the command
-	input := []uint8(wideCmd)
-	encodedCmd := base64.StdEncoding.EncodeToString(input)
+	encodedCmd := base64.StdEncoding.EncodeToString(wideCmd)
 
 	// Create the powershell.exe command line to execute the script
 	return fmt.Sprintf("powershell.exe -EncodedCommand %s", encodedCmd)
+}
+
+func encodeUtf16Le(s string) []byte {
+	d := utf16.Encode([]rune(s))
+	b := make([]byte, len(d)*2)
+	for i, r := range d {
+		b[i*2] = byte(r)
+		b[i*2+1] = byte(r >> 8)
+	}
+	return b
 }

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -8,3 +8,15 @@ func (s *WinRMSuite) TestPowershell(c *C) {
 	psCmd := Powershell("dir")
 	c.Assert(psCmd, Equals, "powershell.exe -EncodedCommand ZABpAHIA")
 }
+
+func (s *WinRMSuite) TestPowershellUnicodeEncodingPortuguese(c *C) {
+	// 'Hello World!' in Portuguese (does not require code points above 255).
+	psCmd := Powershell("'Olá Mundo!'")
+	c.Assert(psCmd, Equals, "powershell.exe -EncodedCommand JwBPAGwA4QAgAE0AdQBuAGQAbwAhACcA")
+}
+
+func (s *WinRMSuite) TestPowershellUnicodeEncodingJapanese(c *C) {
+	// 'Hello World!' in Japanese (requires code points above 255).
+	psCmd := Powershell("'こんにちは世界！'")
+	c.Assert(psCmd, Equals, "powershell.exe -EncodedCommand JwBTMJMwazBhMG8wFk5MdQH/JwA=")
+}


### PR DESCRIPTION
This addresses https://github.com/masterzen/winrm/issues/96