### PR TITLE
Add renegotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,35 +210,50 @@ shell.Close()
 
 For using HTTPS authentication with x 509 cert without checking the CA
 ```go
-	package main
+package main
 
-	import (
-		"github.com/masterzen/winrm"
-		"os"
-		"io/ioutil"
-	)
+import (
+    "github.com/masterzen/winrm"
+    "io/ioutil"
+    "log"
+    "os"
+)
 
-	clientCert, err := ioutil.ReadFile("path/to/cert")
-	if err != nil {
-		panic(err)
-	}
+func main() {
+    clientCert, err := ioutil.ReadFile("/home/example/winrm_client_cert.pem")
+    if err != nil {
+        log.Fatalf("failed to read client certificate: %q", err)
+    }
 
-	clientKey, err := ioutil.ReadFile("path/to/key")
-	if err != nil {
-		panic(err)
-	}
+    clientKey, err := ioutil.ReadFile("/home/example/winrm_client_key.pem")
+    if err != nil {
+        log.Fatalf("failed to read client key: %q", err)
+    }
 
-	winrm.DefaultParameters.TransportDecorator = func() winrm.Transporter {
-		// winrm https module
-		return &winrm.ClientAuthRequest{}
-	}
+    winrm.DefaultParameters.TransportDecorator = func() winrm.Transporter {
+        // winrm https module
+        return &winrm.ClientAuthRequest{}
+    }
 
-	endpoint := winrm.NewEndpoint(host, 5986, false, false, clientCert, clientKey, nil, 0)
-	client, err := winrm.NewClient(endpoint, "Administrator", ""
-	if err != nil {
-		panic(err)
-	}
-	client.Run("ipconfig /all", os.Stdout, os.Stderr)
+    endpoint := winrm.NewEndpoint(
+        "192.168.100.2", // host to connect to
+        5986,            // winrm port
+        true,            // use TLS
+        true,            // Allow insecure connection
+        nil,             // CA certificate
+        clientCert,      // Client Certificate
+        clientKey,       // Client Key
+        0,               // Timeout
+    )
+    client, err := winrm.NewClient(endpoint, "Administrator", "")
+    if err != nil {
+        log.Fatalf("failed to create client: %q", err)
+    }
+    _, err = client.Run("whoami", os.Stdout, os.Stderr)
+    if err != nil {
+        log.Fatalf("failed to run command: %q", err)
+    }
+}
 ```
 
 ## Developing on WinRM

--- a/auth.go
+++ b/auth.go
@@ -14,7 +14,7 @@ import (
 
 type ClientAuthRequest struct {
 	transport http.RoundTripper
-	dial func(network, addr string) (net.Conn, error)
+	dial      func(network, addr string) (net.Conn, error)
 }
 
 func (c *ClientAuthRequest) Transport(endpoint *Endpoint) error {
@@ -35,10 +35,11 @@ func (c *ClientAuthRequest) Transport(endpoint *Endpoint) error {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
+			Renegotiation:      tls.RenegotiateOnceAsClient,
 			InsecureSkipVerify: endpoint.Insecure,
 			Certificates:       []tls.Certificate{cert},
 		},
-		Dial: dial,
+		Dial:                  dial,
 		ResponseHeaderTimeout: endpoint.Timeout,
 	}
 
@@ -113,6 +114,6 @@ func (c ClientAuthRequest) Post(client *Client, request *soap.SoapMessage) (stri
 
 func NewClientAuthRequestWithDial(dial func(network, addr string) (net.Conn, error)) *ClientAuthRequest {
 	return &ClientAuthRequest{
-		dial:dial,
+		dial: dial,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/masterzen/winrm
 
+go 1.14
+
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022


### PR DESCRIPTION
This PR adds TLS renegotiation. Without it, when using client x509 certificates, you get an error like:

```bash
gabriel@rossak:/tmp/ssc$ go run client.go
2020/05/18 16:11:04 failed to run command: "unknown error Post \"https://192.168.122.142:5986/wsman\": local error: tls: no renegotiation"
```

With renegotiation enabled:

```bash
gabriel@rossak:/tmp/ssc$ go run client.go 
win-dceir3c7qnq\administrator
```

