### PR TITLE
Send Stdin EOF on Close()

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,13 +149,7 @@ func (c *Client) RunWithString(command string, stdin string) (string, string, in
 	}
 
 	if len(stdin) > 0 {
-		_, err := cmd.Stdin.Write([]byte(stdin))
-		if err != nil {
-			return "", "", -1, err
-		}
-
-		err = cmd.Stdin.Close()
-
+		_, err := cmd.Stdin.WriteClose([]byte(stdin))
 		if err != nil {
 			return "", "", -1, err
 		}
@@ -202,7 +196,6 @@ func (c Client) RunWithInput(command string, stdout, stderr io.Writer, stdin io.
 	go func() {
 		defer wg.Done()
 		io.Copy(cmd.Stdin, stdin)
-		cmd.Stdin.Close()
 	}()
 	go func() {
 		defer wg.Done()

--- a/command.go
+++ b/command.go
@@ -226,7 +226,7 @@ func min(a int, b int) int {
 // commandWriter implements io.Closer interface
 func (w *commandWriter) Close() error {
 	w.eof = true
-	return w.Close()
+        return nil
 }
 
 // Read data from this Pipe

--- a/fixture_test.go
+++ b/fixture_test.go
@@ -142,6 +142,12 @@ func runWinRMFakeServer(c *C, expectedStdin string) (*httptest.Server, string, i
 			var stdin bytes.Buffer
 			doc, err := xmltree.ParseXML(strings.NewReader(body))
 			c.Assert(err, IsNil)
+			end, err := xPath(doc, "//rsp:Stream[@Name='stdin']/@End")
+			c.Assert(err, IsNil)
+			if end.Bool() {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
 			stdins, err := xPath(doc, "//rsp:Stream[@Name='stdin']")
 			c.Assert(err, IsNil)
 			for _, node := range stdins {

--- a/request.go
+++ b/request.go
@@ -112,7 +112,7 @@ func NewGetOutputRequest(uri, shellId, commandId, streams string, params *Parame
 	return message
 }
 
-func NewSendInputRequest(uri, shellId, commandId string, input []byte, params *Parameters) *soap.SoapMessage {
+func NewSendInputRequest(uri, shellId, commandId string, input []byte, eof bool, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
@@ -131,7 +131,7 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, params *P
 	streams.SetAttr("Name", "stdin")
 	streams.SetAttr("CommandId", commandId)
 	streams.SetContent(content)
-	if input == nil {
+	if eof {
 		streams.SetAttr("End", "true")
 	}
 	return message

--- a/request.go
+++ b/request.go
@@ -131,6 +131,9 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, params *P
 	streams.SetAttr("Name", "stdin")
 	streams.SetAttr("CommandId", commandId)
 	streams.SetContent(content)
+	if input == nil {
+		streams.SetAttr("End", "true")
+	}
 	return message
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ChrisTrenkamp/goxpath"
 	"github.com/ChrisTrenkamp/goxpath/tree"
 	"github.com/ChrisTrenkamp/goxpath/tree/xmltree"
-	"github.com/masterzen/winrm/soap"
 	"github.com/masterzen/simplexml/dom"
+	"github.com/masterzen/winrm/soap"
 	. "gopkg.in/check.v1"
 )
 
@@ -75,13 +75,22 @@ func (s *WinRMSuite) TestGetOutputRequest(c *C) {
 }
 
 func (s *WinRMSuite) TestSendInputRequest(c *C) {
-	request := NewSendInputRequest("http://localhost", "SHELLID", "COMMANDID", []byte{31, 32}, nil)
+	request := NewSendInputRequest("http://localhost", "SHELLID", "COMMANDID", []byte{31, 32}, true, nil)
 	defer request.Free()
 
 	assertXPath(c, request.Doc(), "//a:Action", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send")
 	assertXPath(c, request.Doc(), "//a:To", "http://localhost")
 	assertXPath(c, request.Doc(), "//w:Selector[@Name=\"ShellId\"]", "SHELLID")
 	assertXPath(c, request.Doc(), "//rsp:Send/rsp:Stream[@CommandId=\"COMMANDID\"]", "HyA=")
+	assertXPath(c, request.Doc(), "//rsp:Send/rsp:Stream[@CommandId=\"COMMANDID\"]/@End", "true")
+}
+
+func (s *WinRMSuite) TestSendInputRequestNoEOF(c *C) {
+	request := NewSendInputRequest("http://localhost", "SHELLID", "COMMANDID", []byte{31, 32}, false, nil)
+	defer request.Free()
+
+	assertXPath(c, request.Doc(), "//rsp:Send/rsp:Stream[@CommandId=\"COMMANDID\"]", "HyA=")
+	assertXPathNil(c, request.Doc(), "//rsp:Send/rsp:Stream[@CommandId=\"COMMANDID\"]/@End")
 }
 
 func (s *WinRMSuite) TestSignalRequest(c *C) {


### PR DESCRIPTION
Fixes #104
Closes #82 

Sets `@End = true` in the input stream when closing Stdin or sending a single string instead of a stream.

