### PR TITLE
Go Linter Fixes.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -12,11 +12,13 @@ import (
 	"github.com/masterzen/winrm/soap"
 )
 
+//ClientAuthRequest ClientAuthRequest
 type ClientAuthRequest struct {
 	transport http.RoundTripper
 	dial      func(network, addr string) (net.Conn, error)
 }
 
+//Transport Transport
 func (c *ClientAuthRequest) Transport(endpoint *Endpoint) error {
 	cert, err := tls.X509KeyPair(endpoint.Cert, endpoint.Key)
 	if err != nil {
@@ -80,6 +82,7 @@ func parse(response *http.Response) (string, error) {
 	return "", fmt.Errorf("invalid content type")
 }
 
+//Post Post
 func (c ClientAuthRequest) Post(client *Client, request *soap.SoapMessage) (string, error) {
 	httpClient := &http.Client{Transport: c.transport}
 
@@ -112,6 +115,7 @@ func (c ClientAuthRequest) Post(client *Client, request *soap.SoapMessage) (stri
 	return body, err
 }
 
+//NewClientAuthRequestWithDial NewClientAuthRequestWithDial
 func NewClientAuthRequestWithDial(dial func(network, addr string) (net.Conn, error)) *ClientAuthRequest {
 	return &ClientAuthRequest{
 		dial: dial,

--- a/command_test.go
+++ b/command_test.go
@@ -75,15 +75,14 @@ func (s *WinRMSuite) TestStdinCommand(c *C) {
 		if strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send") {
 			c.Assert(message.String(), Contains, "c3RhbmRhcmQgaW5wdXQ=")
 			return "", nil
+		}
+		if strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command") {
+			return executeCommandResponse, nil
+		} else if count != 1 && strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive") {
+			count = 1
+			return outputResponse, nil
 		} else {
-			if strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command") {
-				return executeCommandResponse, nil
-			} else if count != 1 && strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive") {
-				count = 1
-				return outputResponse, nil
-			} else {
-				return doneCommandResponse, nil
-			}
+			return doneCommandResponse, nil
 		}
 	}
 	client.http = r

--- a/http.go
+++ b/http.go
@@ -115,12 +115,14 @@ func (c clientRequest) Post(client *Client, request *soap.SoapMessage) (string, 
 	return body, err
 }
 
+//NewClientWithDial NewClientWithDial
 func NewClientWithDial(dial func(network, addr string) (net.Conn, error)) *clientRequest {
 	return &clientRequest{
 		dial: dial,
 	}
 }
 
+//NewClientWithProxyFunc NewClientWithProxyFunc
 func NewClientWithProxyFunc(proxyfunc func(req *http.Request) (*url.URL, error)) *clientRequest {
 	return &clientRequest{
 		proxyfunc: proxyfunc,

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,9 +1,10 @@
 package winrm
 
 import (
+	"net"
+
 	"github.com/Azure/go-ntlmssp"
 	"github.com/masterzen/winrm/soap"
-	"net"
 )
 
 // ClientNTLM provides a transport via NTLMv2
@@ -23,11 +24,11 @@ func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, err
 	return c.clientRequest.Post(client, request)
 }
 
-
+//NewClientNTLMWithDial NewClientNTLMWithDial
 func NewClientNTLMWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
 	return &ClientNTLM{
 		clientRequest{
-			dial:dial,
+			dial: dial,
 		},
 	}
 }

--- a/request.go
+++ b/request.go
@@ -47,14 +47,14 @@ func NewOpenShellRequest(uri string, params *Parameters) *soap.SoapMessage {
 }
 
 // NewDeleteShellRequest ...
-func NewDeleteShellRequest(uri, shellId string, params *Parameters) *soap.SoapMessage {
+func NewDeleteShellRequest(uri, shellID string, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
 	message := soap.NewMessage()
 	defaultHeaders(message, uri, params).
 		Action("http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete").
-		ShellId(shellId).
+		ShellId(shellID).
 		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
 		Build()
 
@@ -64,7 +64,7 @@ func NewDeleteShellRequest(uri, shellId string, params *Parameters) *soap.SoapMe
 }
 
 // NewExecuteCommandRequest exec command on specific shellID
-func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, params *Parameters) *soap.SoapMessage {
+func NewExecuteCommandRequest(uri, shellID, command string, arguments []string, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
@@ -72,7 +72,7 @@ func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, 
 	defaultHeaders(message, uri, params).
 		Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command").
 		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
-		ShellId(shellId).
+		ShellId(shellID).
 		AddOption(soap.NewHeaderOption("WINRS_CONSOLEMODE_STDIN", "TRUE")).
 		AddOption(soap.NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).
 		Build()
@@ -93,7 +93,8 @@ func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, 
 	return message
 }
 
-func NewGetOutputRequest(uri, shellId, commandId, streams string, params *Parameters) *soap.SoapMessage {
+//NewGetOutputRequest NewGetOutputRequest
+func NewGetOutputRequest(uri, shellID, commandID, streams string, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
@@ -101,18 +102,19 @@ func NewGetOutputRequest(uri, shellId, commandId, streams string, params *Parame
 	defaultHeaders(message, uri, params).
 		Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive").
 		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
-		ShellId(shellId).
+		ShellId(shellID).
 		Build()
 
 	receive := message.CreateBodyElement("Receive", soap.DOM_NS_WIN_SHELL)
 	desiredStreams := message.CreateElement(receive, "DesiredStream", soap.DOM_NS_WIN_SHELL)
-	desiredStreams.SetAttr("CommandId", commandId)
+	desiredStreams.SetAttr("CommandId", commandID)
 	desiredStreams.SetContent(streams)
 
 	return message
 }
 
-func NewSendInputRequest(uri, shellId, commandId string, input []byte, eof bool, params *Parameters) *soap.SoapMessage {
+//NewSendInputRequest NewSendInputRequest
+func NewSendInputRequest(uri, shellID, commandID string, input []byte, eof bool, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
@@ -121,7 +123,7 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, eof bool,
 	defaultHeaders(message, uri, params).
 		Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send").
 		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
-		ShellId(shellId).
+		ShellId(shellID).
 		Build()
 
 	content := base64.StdEncoding.EncodeToString(input)
@@ -129,7 +131,7 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, eof bool,
 	send := message.CreateBodyElement("Send", soap.DOM_NS_WIN_SHELL)
 	streams := message.CreateElement(send, "Stream", soap.DOM_NS_WIN_SHELL)
 	streams.SetAttr("Name", "stdin")
-	streams.SetAttr("CommandId", commandId)
+	streams.SetAttr("CommandId", commandID)
 	streams.SetContent(content)
 	if eof {
 		streams.SetAttr("End", "true")
@@ -137,7 +139,8 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, eof bool,
 	return message
 }
 
-func NewSignalRequest(uri string, shellId string, commandId string, params *Parameters) *soap.SoapMessage {
+//NewSignalRequest NewSignalRequest
+func NewSignalRequest(uri string, shellID string, commandID string, params *Parameters) *soap.SoapMessage {
 	if params == nil {
 		params = DefaultParameters
 	}
@@ -146,11 +149,11 @@ func NewSignalRequest(uri string, shellId string, commandId string, params *Para
 	defaultHeaders(message, uri, params).
 		Action("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal").
 		ResourceURI("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd").
-		ShellId(shellId).
+		ShellId(shellID).
 		Build()
 
 	signal := message.CreateBodyElement("Signal", soap.DOM_NS_WIN_SHELL)
-	signal.SetAttr("CommandId", commandId)
+	signal.SetAttr("CommandId", commandID)
 	code := message.CreateElement(signal, "Code", soap.DOM_NS_WIN_SHELL)
 	code.SetContent("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate")
 

--- a/response.go
+++ b/response.go
@@ -44,6 +44,7 @@ func xPath(node tree.Node, xpath string) (tree.NodeSet, error) {
 	return nodes, nil
 }
 
+//ParseOpenShellResponse ParseOpenShellResponse
 func ParseOpenShellResponse(response string) (string, error) {
 	doc, err := xmltree.ParseXML(strings.NewReader(response))
 	if err != nil {
@@ -52,6 +53,7 @@ func ParseOpenShellResponse(response string) (string, error) {
 	return first(doc, "//w:Selector[@Name='ShellId']")
 }
 
+//ParseExecuteCommandResponse ParseExecuteCommandResponse
 func ParseExecuteCommandResponse(response string) (string, error) {
 	doc, err := xmltree.ParseXML(strings.NewReader(response))
 	if err != nil {
@@ -60,6 +62,7 @@ func ParseExecuteCommandResponse(response string) (string, error) {
 	return first(doc, "//rsp:CommandId")
 }
 
+//ParseSlurpOutputErrResponse ParseSlurpOutputErrResponse
 func ParseSlurpOutputErrResponse(response string, stdout, stderr io.Writer) (bool, int, error) {
 	var (
 		finished bool
@@ -94,6 +97,7 @@ func ParseSlurpOutputErrResponse(response string, stdout, stderr io.Writer) (boo
 	return finished, exitCode, err
 }
 
+//ParseSlurpOutputResponse ParseSlurpOutputResponse
 func ParseSlurpOutputResponse(response string, stream io.Writer, streamType string) (bool, int, error) {
 	var (
 		finished bool

--- a/response_test.go
+++ b/response_test.go
@@ -8,23 +8,23 @@ import (
 
 func (s *WinRMSuite) TestOpenShellResponse(c *C) {
 	response := createShellResponse
-	shellId, err := ParseOpenShellResponse(response)
+	shellID, err := ParseOpenShellResponse(response)
 	if err != nil {
 		c.Fatalf("response didn't parse: %s", err)
 	}
 
-	c.Assert("67A74734-DD32-4F10-89DE-49A060483810", Equals, shellId)
+	c.Assert("67A74734-DD32-4F10-89DE-49A060483810", Equals, shellID)
 }
 
 func (s *WinRMSuite) TestExecuteCommandResponse(c *C) {
 	response := executeCommandResponse
 
-	commandId, err := ParseExecuteCommandResponse(response)
+	commandID, err := ParseExecuteCommandResponse(response)
 	if err != nil {
 		c.Fatalf("response didn't parse: %s", err)
 	}
 
-	c.Assert("1A6DEE6B-EC68-4DD6-87E9-030C0048ECC4", Equals, commandId)
+	c.Assert("1A6DEE6B-EC68-4DD6-87E9-030C0048ECC4", Equals, commandID)
 
 }
 

--- a/shell_test.go
+++ b/shell_test.go
@@ -18,10 +18,9 @@ func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
 			c.Assert(message.String(), Contains, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command")
 			first = false
 			return executeCommandResponse, nil
-		} else {
-			c.Assert(message.String(), Contains, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive")
-			return outputResponse, nil
 		}
+		c.Assert(message.String(), Contains, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive")
+		return outputResponse, nil
 	}
 	client.http = r
 	command, _ := shell.Execute("ipconfig /all")


### PR DESCRIPTION
I've fixed couple of linter warnings.

In https://github.com/masterzen/winrm/blob/c42b5136ff886aff9dba40fb3670281f0d583db8/http.go#L124 line, returned struct should be public (starts with uppercase) to be able to access it's contents. That struct is being used in many places so I haven't touched it.