### PR TITLE
Add Client NTLM With Proxy Func

### DIFF
--- a/ntlm.go
+++ b/ntlm.go
@@ -2,6 +2,8 @@ package winrm
 
 import (
 	"net"
+	"net/http"
+	"net/url"
 
 	"github.com/Azure/go-ntlmssp"
 	"github.com/masterzen/winrm/soap"
@@ -29,6 +31,15 @@ func NewClientNTLMWithDial(dial func(network, addr string) (net.Conn, error)) *C
 	return &ClientNTLM{
 		clientRequest{
 			dial: dial,
+		},
+	}
+}
+
+//NewClientNTLMWithProxyFunc NewClientNTLMWithProxyFunc
+func NewClientNTLMWithProxyFunc(proxyfunc func(req *http.Request) (*url.URL, error)) *ClientNTLM {
+	return &ClientNTLM{
+		clientRequest{
+			proxyfunc: proxyfunc,
 		},
 	}
 }


### PR DESCRIPTION
Creates NewClientNTLMWithProxyFunc function. 

Similar to NewClientWithProxyFunc and NewClientNTLMWithDial, except for NTLM. https://github.com/hashicorp/packer/issues/10343 highlights packer loses NTLM settings if proxyfunc exists, therefore adding this would help resolve this issue in the Packer repository. 