### PR TITLE
Wrapped errors

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -73,7 +73,7 @@ func parse(response *http.Response) (string, error) {
 			}
 		}()
 		if err != nil {
-			return "", fmt.Errorf("error while reading request body %s", err)
+			return "", fmt.Errorf("error while reading request body %w", err)
 		}
 
 		return string(body), nil
@@ -88,7 +88,7 @@ func (c ClientAuthRequest) Post(client *Client, request *soap.SoapMessage) (stri
 
 	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
-		return "", fmt.Errorf("impossible to create http request %s", err)
+		return "", fmt.Errorf("impossible to create http request %w", err)
 	}
 
 	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
@@ -96,12 +96,12 @@ func (c ClientAuthRequest) Post(client *Client, request *soap.SoapMessage) (stri
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("unknown error %s", err)
+		return "", fmt.Errorf("unknown error %w", err)
 	}
 
 	body, err := parse(resp)
 	if err != nil {
-		return "", fmt.Errorf("http response error: %d - %s", resp.StatusCode, err.Error())
+		return "", fmt.Errorf("http response error: %d - %w", resp.StatusCode, err)
 	}
 
 	// if we have different 200 http status code

--- a/client.go
+++ b/client.go
@@ -57,7 +57,7 @@ func NewClientWithParameters(endpoint *Endpoint, user, password string, params *
 
 	// set the transport to some endpoint configuration
 	if err := client.http.Transport(endpoint); err != nil {
-		return nil, fmt.Errorf("Can't parse this key and certs: %s", err)
+		return nil, fmt.Errorf("Can't parse this key and certs: %w", err)
 	}
 
 	return client, nil

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9
 	golang.org/x/crypto v0.0.0-20190222235706-ffb98f73852f // indirect
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
-	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/text v0.3.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 )

--- a/http.go
+++ b/http.go
@@ -29,7 +29,7 @@ func body(response *http.Response) (string, error) {
 			}
 		}()
 		if err != nil {
-			return "", fmt.Errorf("error while reading request body %s", err)
+			return "", fmt.Errorf("error while reading request body %w", err)
 		}
 
 		return string(body), nil
@@ -90,18 +90,18 @@ func (c clientRequest) Post(client *Client, request *soap.SoapMessage) (string, 
 
 	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
-		return "", fmt.Errorf("impossible to create http request %s", err)
+		return "", fmt.Errorf("impossible to create http request %w", err)
 	}
 	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
 	req.SetBasicAuth(client.username, client.password)
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("unknown error %s", err)
+		return "", fmt.Errorf("unknown error %w", err)
 	}
 
 	body, err := body(resp)
 	if err != nil {
-		return "", fmt.Errorf("http response error: %d - %s", resp.StatusCode, err.Error())
+		return "", fmt.Errorf("http response error: %d - %w", resp.StatusCode, err)
 	}
 
 	// if we have different 200 http status code


### PR DESCRIPTION
1. Wrapping the errors returned by winrm, which can help the client package to take better decisions by unwrapping the error.
2. Ran go mod tidy.