### PR TITLE
Expose client.SendMessage

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,7 +80,7 @@ func (c *Client) CreateShell() (*Shell, error) {
 	request := NewOpenShellRequest(c.url, &c.Parameters)
 	defer request.Free()
 
-	response, err := c.sendRequest(request)
+	response, err := c.SendRequest(request)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,11 @@ func (c *Client) NewShell(id string) *Shell {
 	return &Shell{client: c, id: id}
 }
 
-// sendRequest exec the custom http func from the client
-func (c *Client) sendRequest(request *soap.SoapMessage) (string, error) {
+// SendRequest sends a raw SOAP message to the server and returns the
+// raw XML response as text or an error. This function is only useful 
+// if you want to use wsman/WinRM features that are not supported by
+// this library.
+func (c *Client) SendRequest(request *soap.SoapMessage) (string, error) {
 	return c.http.Post(c, request)
 }
 

--- a/command.go
+++ b/command.go
@@ -126,7 +126,7 @@ func (c *Command) Close() error {
 	request := NewSignalRequest(c.client.url, c.shell.id, c.id, &c.client.Parameters)
 	defer request.Free()
 
-	_, err := c.client.sendRequest(request)
+	_, err := c.client.SendRequest(request)
 	return err
 }
 
@@ -140,7 +140,7 @@ func (c *Command) slurpAllOutput() (bool, error) {
 	request := NewGetOutputRequest(c.client.url, c.shell.id, c.id, "stdout stderr", &c.client.Parameters)
 	defer request.Free()
 
-	response, err := c.client.sendRequest(request)
+	response, err := c.client.SendRequest(request)
 	if err != nil {
 		if strings.Contains(err.Error(), "OperationTimeout") {
 			// Operation timeout because there was no command output
@@ -186,7 +186,7 @@ func (c *Command) sendInput(data []byte, eof bool) error {
 	request := NewSendInputRequest(c.client.url, c.shell.id, c.id, data, eof, &c.client.Parameters)
 	defer request.Free()
 
-	_, err := c.client.sendRequest(request)
+	_, err := c.client.SendRequest(request)
 	return err
 }
 

--- a/shell.go
+++ b/shell.go
@@ -20,7 +20,7 @@ func (s *Shell) ExecuteWithContext(ctx context.Context, command string, argument
 	request := NewExecuteCommandRequest(s.client.url, s.id, command, arguments, &s.client.Parameters)
 	defer request.Free()
 
-	response, err := s.client.sendRequest(request)
+	response, err := s.client.SendRequest(request)
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +40,6 @@ func (s *Shell) Close() error {
 	request := NewDeleteShellRequest(s.client.url, s.id, &s.client.Parameters)
 	defer request.Free()
 
-	_, err := s.client.sendRequest(request)
+	_, err := s.client.SendRequest(request)
 	return err
 }


### PR DESCRIPTION
I've been half-fantasizing about writing a PowerShell Remoting Protocol client after glancing the spec at [learn.microsoft.com](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/602ee78e-9a19-45ad-90fa-bb132b7cecec), Python's [pypsrp](https://github.com/jborean93/pypsrp), the PSRP-enabled [Ruby winrm gem](https://github.com/WinRb/WinRM/tree/winrm-v2), PowerShell [source](https://github.com/PowerShell/PowerShell) and the article [A look under the hood at Powershell Remoting through a cross plaform lens](https://www.hurryupandwait.io/blog/a-look-under-the-hood-at-powershell-remoting-through-a-ruby-cross-plaform-lens). 

`masterzen/winrm` already implements the bits for negotiating the connection and sending/receiving wsman/soap messages, but the problem is that it doesn't expose any methods for sending/receiving raw messages. 

This PR exposes the `*winrm.Client`'s `sendMessage` function as `SendMessage` which should be enough to implement any custom functionality on top of the opened connection.

