### PR TITLE
Dry up DOM namespaces list

### DIFF
--- a/soap/namespaces.go
+++ b/soap/namespaces.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Namespaces
+//
 //nolint:stylecheck // we keep the ALL_CAPS names
 const (
 	NS_SOAP_ENV    = "http://www.w3.org/2003/05/soap-envelope"
@@ -21,6 +22,7 @@ const (
 )
 
 // Namespace Prefixes
+//
 //nolint:stylecheck // we keep the ALL_CAPS names
 const (
 	NSP_SOAP_ENV    = "env"
@@ -36,18 +38,19 @@ const (
 )
 
 // DOM Namespaces
+//
 //nolint:stylecheck
 var (
-	DOM_NS_SOAP_ENV    = dom.Namespace{Prefix: "env", Uri: "http://www.w3.org/2003/05/soap-envelope"}
-	DOM_NS_ADDRESSING  = dom.Namespace{Prefix: "a", Uri: "http://schemas.xmlsoap.org/ws/2004/08/addressing"}
-	DOM_NS_CIMBINDING  = dom.Namespace{Prefix: "b", Uri: "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"}
-	DOM_NS_ENUM        = dom.Namespace{Prefix: "n", Uri: "http://schemas.xmlsoap.org/ws/2004/09/enumeration"}
-	DOM_NS_TRANSFER    = dom.Namespace{Prefix: "x", Uri: "http://schemas.xmlsoap.org/ws/2004/09/transfer"}
-	DOM_NS_WSMAN_DMTF  = dom.Namespace{Prefix: "w", Uri: "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"}
-	DOM_NS_WSMAN_MSFT  = dom.Namespace{Prefix: "p", Uri: "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"}
-	DOM_NS_SCHEMA_INST = dom.Namespace{Prefix: "xsi", Uri: "http://www.w3.org/2001/XMLSchema-instance"}
-	DOM_NS_WIN_SHELL   = dom.Namespace{Prefix: "rsp", Uri: "http://schemas.microsoft.com/wbem/wsman/1/windows/shell"}
-	DOM_NS_WSMAN_FAULT = dom.Namespace{Prefix: "f", Uri: "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault"}
+	DOM_NS_SOAP_ENV    = dom.Namespace{Prefix: NSP_SOAP_ENV, Uri: NS_SOAP_ENV}
+	DOM_NS_ADDRESSING  = dom.Namespace{Prefix: NSP_ADDRESSING, Uri: NS_ADDRESSING}
+	DOM_NS_CIMBINDING  = dom.Namespace{Prefix: NSP_CIMBINDING, Uri: NS_CIMBINDING}
+	DOM_NS_ENUM        = dom.Namespace{Prefix: NSP_ENUM, Uri: NS_ENUM}
+	DOM_NS_TRANSFER    = dom.Namespace{Prefix: NSP_TRANSFER, Uri: NS_TRANSFER}
+	DOM_NS_WSMAN_DMTF  = dom.Namespace{Prefix: NSP_WSMAN_DMTF, Uri: NS_WSMAN_DMTF}
+	DOM_NS_WSMAN_MSFT  = dom.Namespace{Prefix: NSP_WSMAN_MSFT, Uri: NS_WSMAN_MSFT}
+	DOM_NS_SCHEMA_INST = dom.Namespace{Prefix: NSP_SCHEMA_INST, Uri: NS_SCHEMA_INST}
+	DOM_NS_WIN_SHELL   = dom.Namespace{Prefix: NSP_WIN_SHELL, Uri: NS_WIN_SHELL}
+	DOM_NS_WSMAN_FAULT = dom.Namespace{Prefix: NSP_WSMAN_FAULT, Uri: NS_WSMAN_FAULT}
 )
 
 var MostUsed = [...]dom.Namespace{


### PR DESCRIPTION
The list contained the same strings that were defined as constants right above the list.

