### PR TITLE
Fix http/timeout while waiting for command output

### DIFF
--- a/command.go
+++ b/command.go
@@ -146,7 +146,8 @@ func (c *Command) slurpAllOutput() (bool, error) {
 
 	response, err := c.client.sendRequest(request)
 	if err != nil {
-		if errWithTimeout, ok := err.(errWithTimeout); ok && errWithTimeout.Timeout() {
+		var errWithTimeout url.Error
+		if errors.As(err, &errWithTimeout) && errWithTimeout.Timeout() {
 			// Operation timeout possibly because there was no command output
 			return false, err
 		}


### PR DESCRIPTION
Fixes #147 

In addition to the existing SOAP OperationTimeout, this PR makes the output retriever check if the error returned from the HTTP request is a http/timeout, which needs to be handled the same way.

