### PR TITLE
Read and close PrepareRequest response body

### DIFF
--- a/encryption.go
+++ b/encryption.go
@@ -120,6 +120,14 @@ func (e *Encryption) PrepareRequest(client *Client, endpoint string) error {
 		return fmt.Errorf("unknown error %w", err)
 	}
 
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return fmt.Errorf("close request body: %w", err)
+	}
+
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("http error %d", resp.StatusCode)
 	}


### PR DESCRIPTION
HTTP response's body should always be read and closed even if it's not used. The `PrepareRequest` function in encryption.go did not do that. This prevents the http client from reusing the same TCP connection to send the next request and a new one is opened, leaving the old one hanging.
