### PR TITLE
Add a golangci-lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,28 @@
+name: Lint (golangci-lint)
+on:
+  pull_request:
+    paths:
+      - '**.go'
+
+jobs:
+  golangci-lint:
+    name: Run golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-cache: true
+          only-new-issues: false
+          args: --verbose --timeout=10m
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: "1.14"
+  go: "1.21"
   deadline: 10m
   allow-parallel-runners: true
 linters:
@@ -39,6 +39,6 @@ linters-settings:
     ignore-generated-header: true
     severity: error
   staticcheck:
-    go: "1.14"
+    go: "1.21"
   stylecheck:
-    go: "1.14"
+    go: "1.21"


### PR DESCRIPTION
There's a `.golangci.yml` but no workflow. There are a some linting errors and warnings, so maybe need to fix those first. Most of them seem to be in the encryption.go.

