### PR TITLE
Add Parameter used by Command to allow connection timeouts to complete the command

### DIFF
--- a/command.go
+++ b/command.go
@@ -144,7 +144,7 @@ func (c *Command) slurpAllOutput() (bool, error) {
 	response, err := c.client.sendRequest(request)
 	if err != nil {
 		var errWithTimeout *url.Error
-		if errors.As(err, &errWithTimeout) && errWithTimeout.Timeout() {
+		if !c.client.AllowTimeout && errors.As(err, &errWithTimeout) && errWithTimeout.Timeout() {
 			// Operation timeout because the server didn't respond in time
 			return false, err
 		}

--- a/parameters.go
+++ b/parameters.go
@@ -8,6 +8,7 @@ type Parameters struct {
 	Timeout            string
 	Locale             string
 	EnvelopeSize       int
+	AllowTimeout       bool // Allow Commands to finish if connection times out. Useful if the command causes the Host to shut down.
 	TransportDecorator func() Transporter
 	Dial               func(network, addr string) (net.Conn, error)
 }


### PR DESCRIPTION
Fixes #161 where commands that cause the host to shut down never complete and run forever.