### PR TITLE
Update runner image to ubuntu-latest in GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   gotest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The image used in the 'Run unit tests' workflow (ubuntu-20.04) has been deprecated since 2025-02-01.

This PR updates is to use ubuntu-latest (the same image tag is used for the lint action).