### PR TITLE
Replace Azure/go-ntlmssp with bodgit/ntlmssp for NTLM auth with encryption support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,19 @@
+version: "2"
+
 run:
   go: "1.21"
-  deadline: 10m
+  timeout: 10m
   allow-parallel-runners: true
+
 linters:
-  disable-all: true
+  default: none
   enable:
     # Default linters
-    - deadcode
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
-    - typecheck
     - unused
-    - varcheck
     # Optional linters
     - asciicheck
     - bidichk
@@ -26,19 +24,15 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - exportloopref
     - gosec
     - misspell
     - noctx
     - nolintlint
     - revive
-    - stylecheck
     - whitespace
-linters-settings:
-  revive:
-    ignore-generated-header: true
-    severity: error
-  staticcheck:
-    go: "1.21"
-  stylecheck:
-    go: "1.21"
+
+  settings:
+    revive:
+      severity: error
+    staticcheck:
+      go: "1.21"

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,326 +1,71 @@
 # WinRM NTLM Auth Fix — Implementation Plan
 
-## Current State Analysis
+## Status: COMPLETED
 
-The codebase has **two NTLM auth paths**:
+All sprints have been implemented. Azure/go-ntlmssp has been fully replaced with bodgit/ntlmssp.
 
+## What Changed
+
+### Before
 | Transport | File | Library | Encryption | Works with default Windows? |
 |-----------|------|---------|------------|-----------------------------|
 | `ClientNTLM` | `ntlm.go` | Azure/go-ntlmssp | No | No (`AllowUnencrypted=false` by default) |
 | `Encryption` | `encryption.go` | bodgit/ntlmssp | Yes (sealing) | Yes |
 
-**The problem:** Azure/go-ntlmssp does NOT support NTLM sealing (message encryption). Windows servers default to `AllowUnencrypted = false`, so `ClientNTLM` fails in practice. The `Encryption` struct already uses bodgit/ntlmssp (which supports sealing), but it creates fresh NTLM sessions per request (expensive) and has some error handling gaps.
+### After
+| Transport | File | Library | Encryption | Works with default Windows? |
+|-----------|------|---------|------------|-----------------------------|
+| `ClientNTLM` | `ntlm.go` | bodgit/ntlmssp | Optional | Yes (with encryption) |
+| `Encryption` | `encryption.go` | delegates to ClientNTLM | Yes (sealing) | Yes |
 
-**The fix:** Replace Azure/go-ntlmssp with bodgit/ntlmssp everywhere, remove the Azure dependency, and improve the overall NTLM transport.
+## Completed Sprints
 
----
+### Sprint 1: Core NTLM Transport Replacement
+- [x] Rewrote `ntlm.go` — replaced Azure `Negotiator` with bodgit `http.Client`
+- [x] Extracted `parseUsernameAndDomain()` shared helper
+- [x] Removed `github.com/Azure/go-ntlmssp` from `go.mod`
+- [x] All tests pass, build clean
 
-## Key Discovery: bodgit/ntlmssp/http Already Does Everything
+### Sprint 2: Unified Encrypted NTLM
+- [x] Added `useEncryption` flag to `ClientNTLM`
+- [x] Simplified `encryption.go` from ~440 lines to ~53 lines (delegates to `ClientNTLM`)
+- [x] Added convenience constructors: `NewClientNTLMEncrypted()`, `NewClientNTLMEncryptedWithDial()`, `NewClientNTLMEncryptedWithProxyFunc()`
 
-The `bodgit/ntlmssp/http` package provides:
-- `http.Client` — wraps `*http.Client` with NTLM auth handshake handling
-- `Encryption(true)` option — enables automatic SOAP body sealing/unsealing
-- `Wrap()`/`Unwrap()` — MIME multipart encryption envelope handling
-- `SendCBT(true)` — Channel Binding Token support for HTTPS
+### Sprint 3: Session Caching
+- [x] Cached bodgit NTLM clients across `Post()` calls (avoids re-handshaking)
+- [x] Session invalidation on credential change
+- [x] Session reset on encrypted request failure (auto-recovery)
+- [x] Thread-safe with `sync.Mutex`
 
-This means both `ClientNTLM` (auth only) and `Encryption` (auth + sealing) can be built on top of bodgit's http.Client with different options.
+### Sprint 4: Tests & Cleanup
+- [x] Added tests for `parseUsernameAndDomain` (backslash, @-sign, plain)
+- [x] Added tests for `NewEncryption` (ntlm, unsupported protocol)
+- [x] Added tests for all new constructors
+- [x] Added test for `Encryption` wrapper Transport
+- [x] `go vet` passes clean
+- [x] Zero Azure references in codebase
 
----
+## Usage Examples
 
-## Sprint 1: Core NTLM Transport Replacement (Sequential — Foundation)
-
-**Goal:** Replace Azure/go-ntlmssp with bodgit/ntlmssp in `ClientNTLM`. After this sprint, unencrypted NTLM auth uses bodgit.
-
-### Task 1.1: Rewrite `ntlm.go`
-
-**Current code (Azure):**
+### NTLM without encryption (requires AllowUnencrypted=true on server)
 ```go
-import "github.com/Azure/go-ntlmssp"
-
-func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
-    c.clientRequest.Transport(endpoint)
-    c.clientRequest.transport = &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
-    return nil
-}
-
-func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
-    return c.clientRequest.Post(client, request)
-}
+params.TransportDecorator = func() Transporter { return &ClientNTLM{} }
 ```
 
-**New code (bodgit):**
+### NTLM with encryption (works with default Windows config)
 ```go
-import (
-    "github.com/bodgit/ntlmssp"
-    ntlmhttp "github.com/bodgit/ntlmssp/http"
-)
-
-type ClientNTLM struct {
-    clientRequest
-    useEncryption bool
-}
-
-func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
-    return c.clientRequest.Transport(endpoint)
-}
-
-func (c *ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
-    // 1. Parse username/domain from client.username
-    // 2. Create bodgit ntlmssp.Client with SetUserInfo, SetDomain
-    // 3. Create *http.Client with base transport
-    // 4. Create bodgit http.Client wrapping it
-    // 5. Build and send POST request
-    // 6. Return response body
-}
+params.TransportDecorator = func() Transporter { return NewClientNTLMEncrypted() }
+// or equivalently:
+params.TransportDecorator = func() Transporter { enc, _ := NewEncryption("ntlm"); return enc }
 ```
 
-**Key changes:**
-- Remove Azure Negotiator — bodgit doesn't implement `http.RoundTripper`
-- Move the HTTP request logic INTO `ClientNTLM.Post()` instead of delegating to `clientRequest.Post()`
-- Parse `DOMAIN\user` and `user@domain` formats (reuse logic from `encryption.go:83-94`)
-- Create bodgit client per Post() call initially (matches current encryption.go behavior)
-
-### Task 1.2: Add username parsing helper
-
-Extract the username/domain parsing from `encryption.go:83-94` into a shared helper:
+### NTLM with encryption + custom dialer
 ```go
-func parseUsernameAndDomain(username string) (user, domain string) {
-    if strings.Contains(username, "@") {
-        parts := strings.Split(username, "@")
-        return parts[0], parts[1]
-    } else if strings.Contains(username, "\\") {
-        parts := strings.Split(username, "\\")
-        return parts[1], parts[0]
-    }
-    return username, ""
-}
+params.TransportDecorator = func() Transporter { return NewClientNTLMEncryptedWithDial(myDialer) }
 ```
 
-### Task 1.3: Remove Azure/go-ntlmssp dependency
-
-- Remove `github.com/Azure/go-ntlmssp` from `go.mod`
-- Run `go mod tidy`
-- Verify no remaining Azure imports
-
-### Task 1.4: Update tests
-
-- Update `ntlm_test.go` — tests use a local HTTP test server, should work with bodgit
-- Verify `go test ./...` passes
-
-### Task 1.5: Verify build
-
-- `go build ./...`
-- `go vet ./...`
-
----
-
-## Sprint 2: Refactor Encryption & Add Encrypted NTLM to ClientNTLM (Can Parallelize)
-
-**Goal:** Unify the NTLM code paths. Make `ClientNTLM` support optional encryption. Simplify `Encryption` to delegate to `ClientNTLM`.
-
-### Task 2.1: Add encryption support to ClientNTLM
-
-Add a `useEncryption` field to `ClientNTLM`:
-```go
-type ClientNTLM struct {
-    clientRequest
-    useEncryption bool
-}
-```
-
-When `useEncryption` is true, create the bodgit http.Client with `Encryption(true)`:
-- bodgit handles MIME wrapping/unwrapping automatically
-- No manual `encryptMessage`/`decryptMessage` needed
-
-**Two-step approach for encrypted NTLM:**
-1. First request: empty POST to establish NTLM session (handshake)
-2. Second request: POST with SOAP body (bodgit wraps/unwraps automatically)
-
-This matches the current `encryption.go` PrepareRequest + PrepareEncryptedRequest pattern but using bodgit's built-in encryption.
-
-### Task 2.2: Simplify `encryption.go`
-
-Refactor `Encryption` struct to delegate to `ClientNTLM`:
-```go
-type Encryption struct {
-    ntlm *ClientNTLM  // ClientNTLM with useEncryption=true
-    protocol string
-}
-
-func NewEncryption(protocol string) (*Encryption, error) {
-    if protocol != "ntlm" {
-        return nil, fmt.Errorf(...)
-    }
-    return &Encryption{
-        ntlm: &ClientNTLM{useEncryption: true},
-        protocol: protocol,
-    }, nil
-}
-
-func (e *Encryption) Post(client *Client, request *soap.SoapMessage) (string, error) {
-    return e.ntlm.Post(client, request)
-}
-```
-
-This removes ~300 lines of manual MIME wrapping code (`encryptMessage`, `decryptMessage`, `buildNTLMMessage`, `decryptNtlmMessage`, `ParseEncryptedResponse`, `PrepareEncryptedRequest`).
-
-### Task 2.3: Add convenience constructors
-
-```go
-// NewClientNTLMEncrypted creates an NTLM transport with message encryption (sealing).
-// This works with the default Windows AllowUnencrypted=false setting.
-func NewClientNTLMEncrypted() *ClientNTLM {
-    return &ClientNTLM{useEncryption: true}
-}
-
-func NewClientNTLMEncryptedWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
-    return &ClientNTLM{
-        clientRequest: clientRequest{dial: dial},
-        useEncryption: true,
-    }
-}
-```
-
----
-
-## Sprint 3: Session Management & Performance (Sequential — After Sprint 2)
-
-**Goal:** Reuse NTLM sessions across Post() calls to avoid re-handshaking.
-
-### Task 3.1: Cache bodgit clients in ClientNTLM
-
-Instead of creating fresh bodgit clients per Post() call, cache them:
-```go
-type ClientNTLM struct {
-    clientRequest
-    useEncryption bool
-
-    // Cached session state
-    mu         sync.Mutex
-    ntlmClient *ntlmssp.Client
-    ntlmHTTP   *ntlmhttp.Client
-    lastUser   string  // Invalidate cache if user changes
-}
-```
-
-- Lazy initialization on first Post() call
-- Invalidate if username/password changes
-- Thread-safe with mutex
-
-### Task 3.2: Handle session expiry
-
-If the server returns 401 after a previously successful session:
-- Detect this condition
-- Create fresh bodgit clients
-- Retry the request
-
-### Task 3.3: Connection keep-alive tuning
-
-Ensure the base HTTP transport is configured for keep-alive:
-- Verify `DisableKeepAlives` is false (bodgit requires this)
-- Set appropriate idle connection timeout
-- Consider connection pooling settings
-
----
-
-## Sprint 4: Testing & Polish (Can Parallelize)
-
-### Task 4.1: Unit tests for new NTLM transport (Agent: test-writer)
-
-- Test `ClientNTLM.Post()` with mock server that does NTLM handshake
-- Test `parseUsernameAndDomain()` with various formats:
-  - `user` → user, ""
-  - `DOMAIN\user` → user, DOMAIN
-  - `user@domain.com` → user, domain.com
-- Test `ClientNTLM` with encryption enabled
-- Test session reuse (multiple Post() calls)
-- Test error handling (connection refused, 401, 500)
-
-### Task 4.2: Unit tests for simplified Encryption (Agent: test-writer)
-
-- Test `Encryption.Post()` delegates correctly
-- Test backwards compatibility (same `NewEncryption("ntlm")` API)
-- Test protocol validation (only "ntlm" supported)
-
-### Task 4.3: Integration test helpers (Agent: test-writer)
-
-Update `development/winrm-tests.sh` or add Go integration tests:
-- Test against real Windows VM (if available via Vagrant)
-- Test with AllowUnencrypted=false (default)
-- Test with AllowUnencrypted=true
-- Test DOMAIN\user and user@domain formats
-
-### Task 4.4: Code cleanup
-
-- Run `golangci-lint` (per `.golangci.yml`)
-- Fix any linting issues
-- Ensure consistent error handling patterns
-- Remove any dead code
-
----
-
-## Agent Parallelization Strategy
-
-```
-Sprint 1 (Sequential - Must complete first)
-├── Agent A: Rewrite ntlm.go + add username helper
-│   Files: ntlm.go (new username parsing utility)
-│
-└── After Agent A completes:
-    └── Agent B: Remove Azure dep, run tests, verify build
-        Files: go.mod, go.sum
-
-Sprint 2 (After Sprint 1, tasks can parallelize)
-├── Agent C: Add encryption to ClientNTLM + simplify encryption.go
-│   Files: ntlm.go, encryption.go
-│
-└── Agent D: Add convenience constructors + update factory functions
-    Files: ntlm.go, parameters.go (if needed)
-
-Sprint 3 (After Sprint 2)
-└── Agent E: Session caching + keep-alive tuning
-    Files: ntlm.go
-
-Sprint 4 (After Sprint 2, can parallelize with Sprint 3)
-├── Agent F: Write unit tests
-│   Files: ntlm_test.go, encryption_test.go
-│
-└── Agent G: Lint + cleanup
-    Files: all
-```
-
----
-
-## File Change Summary
-
-| File | Change | Sprint |
-|------|--------|--------|
-| `ntlm.go` | **Major rewrite** — Replace Azure with bodgit, add encryption support | 1, 2 |
-| `encryption.go` | **Simplify** — Delegate to ClientNTLM | 2 |
-| `go.mod` | Remove Azure/go-ntlmssp, run tidy | 1 |
-| `ntlm_test.go` | Update for new API | 1, 4 |
-| `encryption_test.go` | New tests | 4 |
-
----
-
-## Risk Assessment
-
-| Risk | Impact | Mitigation |
-|------|--------|------------|
-| bodgit http.Client first-request body not encrypted | Server rejects unencrypted body | Use two-step approach: empty auth POST, then encrypted POST |
-| Session expiry between requests | 401 errors mid-operation | Detect and re-establish session (Sprint 3) |
-| bodgit API changes | Build breaks | Pin dependency version in go.mod |
-| Backwards API compatibility | Users' code breaks | Keep same Transporter interface, same constructor signatures |
-| NTLM handshake per request (performance) | Slow operations | Session caching (Sprint 3) |
-
----
-
-## Success Criteria
-
-1. `go build ./...` succeeds with zero Azure/go-ntlmssp references
-2. `go test ./...` passes
-3. `ClientNTLM` works for NTLM auth without encryption (AllowUnencrypted=true)
-4. `ClientNTLM` with encryption works with default Windows config (AllowUnencrypted=false)
-5. `Encryption` struct maintains backwards-compatible API
-6. `DOMAIN\user` and `user@domain` formats work
-7. No Azure/go-ntlmssp in go.mod
+### Domain user formats
+All three formats are supported:
+- `DOMAIN\user`
+- `user@domain.com`
+- `user` (no domain)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,326 @@
+# WinRM NTLM Auth Fix — Implementation Plan
+
+## Current State Analysis
+
+The codebase has **two NTLM auth paths**:
+
+| Transport | File | Library | Encryption | Works with default Windows? |
+|-----------|------|---------|------------|-----------------------------|
+| `ClientNTLM` | `ntlm.go` | Azure/go-ntlmssp | No | No (`AllowUnencrypted=false` by default) |
+| `Encryption` | `encryption.go` | bodgit/ntlmssp | Yes (sealing) | Yes |
+
+**The problem:** Azure/go-ntlmssp does NOT support NTLM sealing (message encryption). Windows servers default to `AllowUnencrypted = false`, so `ClientNTLM` fails in practice. The `Encryption` struct already uses bodgit/ntlmssp (which supports sealing), but it creates fresh NTLM sessions per request (expensive) and has some error handling gaps.
+
+**The fix:** Replace Azure/go-ntlmssp with bodgit/ntlmssp everywhere, remove the Azure dependency, and improve the overall NTLM transport.
+
+---
+
+## Key Discovery: bodgit/ntlmssp/http Already Does Everything
+
+The `bodgit/ntlmssp/http` package provides:
+- `http.Client` — wraps `*http.Client` with NTLM auth handshake handling
+- `Encryption(true)` option — enables automatic SOAP body sealing/unsealing
+- `Wrap()`/`Unwrap()` — MIME multipart encryption envelope handling
+- `SendCBT(true)` — Channel Binding Token support for HTTPS
+
+This means both `ClientNTLM` (auth only) and `Encryption` (auth + sealing) can be built on top of bodgit's http.Client with different options.
+
+---
+
+## Sprint 1: Core NTLM Transport Replacement (Sequential — Foundation)
+
+**Goal:** Replace Azure/go-ntlmssp with bodgit/ntlmssp in `ClientNTLM`. After this sprint, unencrypted NTLM auth uses bodgit.
+
+### Task 1.1: Rewrite `ntlm.go`
+
+**Current code (Azure):**
+```go
+import "github.com/Azure/go-ntlmssp"
+
+func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
+    c.clientRequest.Transport(endpoint)
+    c.clientRequest.transport = &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
+    return nil
+}
+
+func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
+    return c.clientRequest.Post(client, request)
+}
+```
+
+**New code (bodgit):**
+```go
+import (
+    "github.com/bodgit/ntlmssp"
+    ntlmhttp "github.com/bodgit/ntlmssp/http"
+)
+
+type ClientNTLM struct {
+    clientRequest
+    useEncryption bool
+}
+
+func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
+    return c.clientRequest.Transport(endpoint)
+}
+
+func (c *ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
+    // 1. Parse username/domain from client.username
+    // 2. Create bodgit ntlmssp.Client with SetUserInfo, SetDomain
+    // 3. Create *http.Client with base transport
+    // 4. Create bodgit http.Client wrapping it
+    // 5. Build and send POST request
+    // 6. Return response body
+}
+```
+
+**Key changes:**
+- Remove Azure Negotiator — bodgit doesn't implement `http.RoundTripper`
+- Move the HTTP request logic INTO `ClientNTLM.Post()` instead of delegating to `clientRequest.Post()`
+- Parse `DOMAIN\user` and `user@domain` formats (reuse logic from `encryption.go:83-94`)
+- Create bodgit client per Post() call initially (matches current encryption.go behavior)
+
+### Task 1.2: Add username parsing helper
+
+Extract the username/domain parsing from `encryption.go:83-94` into a shared helper:
+```go
+func parseUsernameAndDomain(username string) (user, domain string) {
+    if strings.Contains(username, "@") {
+        parts := strings.Split(username, "@")
+        return parts[0], parts[1]
+    } else if strings.Contains(username, "\\") {
+        parts := strings.Split(username, "\\")
+        return parts[1], parts[0]
+    }
+    return username, ""
+}
+```
+
+### Task 1.3: Remove Azure/go-ntlmssp dependency
+
+- Remove `github.com/Azure/go-ntlmssp` from `go.mod`
+- Run `go mod tidy`
+- Verify no remaining Azure imports
+
+### Task 1.4: Update tests
+
+- Update `ntlm_test.go` — tests use a local HTTP test server, should work with bodgit
+- Verify `go test ./...` passes
+
+### Task 1.5: Verify build
+
+- `go build ./...`
+- `go vet ./...`
+
+---
+
+## Sprint 2: Refactor Encryption & Add Encrypted NTLM to ClientNTLM (Can Parallelize)
+
+**Goal:** Unify the NTLM code paths. Make `ClientNTLM` support optional encryption. Simplify `Encryption` to delegate to `ClientNTLM`.
+
+### Task 2.1: Add encryption support to ClientNTLM
+
+Add a `useEncryption` field to `ClientNTLM`:
+```go
+type ClientNTLM struct {
+    clientRequest
+    useEncryption bool
+}
+```
+
+When `useEncryption` is true, create the bodgit http.Client with `Encryption(true)`:
+- bodgit handles MIME wrapping/unwrapping automatically
+- No manual `encryptMessage`/`decryptMessage` needed
+
+**Two-step approach for encrypted NTLM:**
+1. First request: empty POST to establish NTLM session (handshake)
+2. Second request: POST with SOAP body (bodgit wraps/unwraps automatically)
+
+This matches the current `encryption.go` PrepareRequest + PrepareEncryptedRequest pattern but using bodgit's built-in encryption.
+
+### Task 2.2: Simplify `encryption.go`
+
+Refactor `Encryption` struct to delegate to `ClientNTLM`:
+```go
+type Encryption struct {
+    ntlm *ClientNTLM  // ClientNTLM with useEncryption=true
+    protocol string
+}
+
+func NewEncryption(protocol string) (*Encryption, error) {
+    if protocol != "ntlm" {
+        return nil, fmt.Errorf(...)
+    }
+    return &Encryption{
+        ntlm: &ClientNTLM{useEncryption: true},
+        protocol: protocol,
+    }, nil
+}
+
+func (e *Encryption) Post(client *Client, request *soap.SoapMessage) (string, error) {
+    return e.ntlm.Post(client, request)
+}
+```
+
+This removes ~300 lines of manual MIME wrapping code (`encryptMessage`, `decryptMessage`, `buildNTLMMessage`, `decryptNtlmMessage`, `ParseEncryptedResponse`, `PrepareEncryptedRequest`).
+
+### Task 2.3: Add convenience constructors
+
+```go
+// NewClientNTLMEncrypted creates an NTLM transport with message encryption (sealing).
+// This works with the default Windows AllowUnencrypted=false setting.
+func NewClientNTLMEncrypted() *ClientNTLM {
+    return &ClientNTLM{useEncryption: true}
+}
+
+func NewClientNTLMEncryptedWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
+    return &ClientNTLM{
+        clientRequest: clientRequest{dial: dial},
+        useEncryption: true,
+    }
+}
+```
+
+---
+
+## Sprint 3: Session Management & Performance (Sequential — After Sprint 2)
+
+**Goal:** Reuse NTLM sessions across Post() calls to avoid re-handshaking.
+
+### Task 3.1: Cache bodgit clients in ClientNTLM
+
+Instead of creating fresh bodgit clients per Post() call, cache them:
+```go
+type ClientNTLM struct {
+    clientRequest
+    useEncryption bool
+
+    // Cached session state
+    mu         sync.Mutex
+    ntlmClient *ntlmssp.Client
+    ntlmHTTP   *ntlmhttp.Client
+    lastUser   string  // Invalidate cache if user changes
+}
+```
+
+- Lazy initialization on first Post() call
+- Invalidate if username/password changes
+- Thread-safe with mutex
+
+### Task 3.2: Handle session expiry
+
+If the server returns 401 after a previously successful session:
+- Detect this condition
+- Create fresh bodgit clients
+- Retry the request
+
+### Task 3.3: Connection keep-alive tuning
+
+Ensure the base HTTP transport is configured for keep-alive:
+- Verify `DisableKeepAlives` is false (bodgit requires this)
+- Set appropriate idle connection timeout
+- Consider connection pooling settings
+
+---
+
+## Sprint 4: Testing & Polish (Can Parallelize)
+
+### Task 4.1: Unit tests for new NTLM transport (Agent: test-writer)
+
+- Test `ClientNTLM.Post()` with mock server that does NTLM handshake
+- Test `parseUsernameAndDomain()` with various formats:
+  - `user` → user, ""
+  - `DOMAIN\user` → user, DOMAIN
+  - `user@domain.com` → user, domain.com
+- Test `ClientNTLM` with encryption enabled
+- Test session reuse (multiple Post() calls)
+- Test error handling (connection refused, 401, 500)
+
+### Task 4.2: Unit tests for simplified Encryption (Agent: test-writer)
+
+- Test `Encryption.Post()` delegates correctly
+- Test backwards compatibility (same `NewEncryption("ntlm")` API)
+- Test protocol validation (only "ntlm" supported)
+
+### Task 4.3: Integration test helpers (Agent: test-writer)
+
+Update `development/winrm-tests.sh` or add Go integration tests:
+- Test against real Windows VM (if available via Vagrant)
+- Test with AllowUnencrypted=false (default)
+- Test with AllowUnencrypted=true
+- Test DOMAIN\user and user@domain formats
+
+### Task 4.4: Code cleanup
+
+- Run `golangci-lint` (per `.golangci.yml`)
+- Fix any linting issues
+- Ensure consistent error handling patterns
+- Remove any dead code
+
+---
+
+## Agent Parallelization Strategy
+
+```
+Sprint 1 (Sequential - Must complete first)
+├── Agent A: Rewrite ntlm.go + add username helper
+│   Files: ntlm.go (new username parsing utility)
+│
+└── After Agent A completes:
+    └── Agent B: Remove Azure dep, run tests, verify build
+        Files: go.mod, go.sum
+
+Sprint 2 (After Sprint 1, tasks can parallelize)
+├── Agent C: Add encryption to ClientNTLM + simplify encryption.go
+│   Files: ntlm.go, encryption.go
+│
+└── Agent D: Add convenience constructors + update factory functions
+    Files: ntlm.go, parameters.go (if needed)
+
+Sprint 3 (After Sprint 2)
+└── Agent E: Session caching + keep-alive tuning
+    Files: ntlm.go
+
+Sprint 4 (After Sprint 2, can parallelize with Sprint 3)
+├── Agent F: Write unit tests
+│   Files: ntlm_test.go, encryption_test.go
+│
+└── Agent G: Lint + cleanup
+    Files: all
+```
+
+---
+
+## File Change Summary
+
+| File | Change | Sprint |
+|------|--------|--------|
+| `ntlm.go` | **Major rewrite** — Replace Azure with bodgit, add encryption support | 1, 2 |
+| `encryption.go` | **Simplify** — Delegate to ClientNTLM | 2 |
+| `go.mod` | Remove Azure/go-ntlmssp, run tidy | 1 |
+| `ntlm_test.go` | Update for new API | 1, 4 |
+| `encryption_test.go` | New tests | 4 |
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| bodgit http.Client first-request body not encrypted | Server rejects unencrypted body | Use two-step approach: empty auth POST, then encrypted POST |
+| Session expiry between requests | 401 errors mid-operation | Detect and re-establish session (Sprint 3) |
+| bodgit API changes | Build breaks | Pin dependency version in go.mod |
+| Backwards API compatibility | Users' code breaks | Keep same Transporter interface, same constructor signatures |
+| NTLM handshake per request (performance) | Slow operations | Session caching (Sprint 3) |
+
+---
+
+## Success Criteria
+
+1. `go build ./...` succeeds with zero Azure/go-ntlmssp references
+2. `go test ./...` passes
+3. `ClientNTLM` works for NTLM auth without encryption (AllowUnencrypted=true)
+4. `ClientNTLM` with encryption works with default Windows config (AllowUnencrypted=false)
+5. `Encryption` struct maintains backwards-compatible API
+6. `DOMAIN\user` and `user@domain` formats work
+7. No Azure/go-ntlmssp in go.mod

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ _Note_: if you're looking for the `winrm` command-line tool, this has been split
 This is a Go library to execute remote commands on Windows machines through
 the use of WinRM/WinRS.
 
-_Note_: this library doesn't support domain users (it doesn't support GSSAPI nor Kerberos). It's primary target is to execute remote commands on EC2 windows machines.
-
-[![Build Status](https://travis-ci.org/masterzen/winrm.svg?branch=master)](https://travis-ci.org/masterzen/winrm)
-[![Coverage Status](https://coveralls.io/repos/masterzen/winrm/badge.png)](https://coveralls.io/r/masterzen/winrm)
+This library supports:
+- **Basic authentication** for local accounts
+- **NTLM authentication** (NTLMv2) for local and domain accounts (`DOMAIN\user` or `user@domain`)
+- **NTLM with message encryption** (sealing) — works with the default Windows `AllowUnencrypted=false` setting
+- **Kerberos authentication** for domain accounts
+- **Certificate-based authentication** (x509 mutual TLS)
 
 ## Contact
 
@@ -16,12 +18,12 @@ _Note_: this library doesn't support domain users (it doesn't support GSSAPI nor
 
 
 ## Getting Started
-WinRM is available on Windows Server 2008 and up. This project natively supports basic authentication for local accounts, see the steps in the next section on how to prepare the remote Windows machine for this scenario. The authentication model is pluggable, see below for an example on using Negotiate/NTLM authentication (e.g. for connecting to vanilla Azure VMs) or Kerberos authentication (using domain accounts).
+WinRM is available on Windows Server 2008 and up. This project supports multiple authentication methods — see the sections below for how to prepare the remote Windows machine for each scenario. The authentication model is pluggable via the `TransportDecorator` parameter.
 
-_Note_: This library only supports Golang 1.7+
+_Note_: This library requires Go 1.21+
 
 ### Preparing the remote Windows machine for Basic authentication
-This project supports only basic authentication for local accounts (domain users are not supported). The remote windows system must be prepared for winrm:
+The remote windows system must be prepared for winrm:
 
 _For a PowerShell script to do what is described below in one go, check [Richard Downer's blog](http://www.frontiertown.co.uk/2011/12/overthere-control-windows-from-java/)_
 
@@ -41,9 +43,17 @@ __N.B.:__ The `MaxMemoryPerShellMB` option has no effects on some Windows 2008R2
 
 For more information on WinRM, please refer to <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa384426(v=vs.85).aspx">the online documentation at Microsoft's DevCenter</a>.
 
-### Preparing the remote Windows machine for kerberos authentication
-This project supports domain users via kerberos authentication. The remote windows system must be prepared for winrm:
+### Preparing the remote Windows machine for NTLM authentication
 
+NTLM authentication works with the default Windows WinRM configuration. No special server-side setup is required beyond enabling WinRM:
+
+		winrm quickconfig
+		y
+		winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
+
+When using NTLM with encryption (the default and recommended mode), you do **not** need to set `AllowUnencrypted="true"` — the SOAP messages are encrypted using the NTLM security session.
+
+### Preparing the remote Windows machine for Kerberos authentication
 On the remote host, a PowerShell prompt, using the __Run as Administrator__ option and paste in the following lines:
 
                 winrm quickconfig
@@ -66,12 +76,6 @@ make
 
 _Note_: this winrm code doesn't depend anymore on [Gokogiri](https://github.com/moovweb/gokogiri) which means it is now in pure Go.
 
-_Note_: you need go 1.5+. Please check your installation with
-
-```
-go version
-```
-
 ## Command-line usage
 
 For command-line usage check the [winrm-cli project](https://github.com/masterzen/winrm-cli)
@@ -80,157 +84,198 @@ For command-line usage check the [winrm-cli project](https://github.com/masterze
 
 **Warning the API might be subject to change.**
 
+### Basic authentication
+
 For the fast version (this doesn't allow to send input to the command) and it's using HTTP as the transport:
 
 ```go
 package main
 
 import (
-	"github.com/masterzen/winrm"
+	"context"
 	"os"
+
+	"github.com/masterzen/winrm"
 )
 
-endpoint := winrm.NewEndpoint(host, 5986, false, false, nil, nil, nil, 0)
-client, err := winrm.NewClient(endpoint, "Administrator", "secret")
+func main() {
+	endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	client, err := winrm.NewClient(endpoint, "Administrator", "secret")
+	if err != nil {
+		panic(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.RunWithContext(ctx, "ipconfig /all", os.Stdout, os.Stderr)
+}
+```
+
+or with stdin:
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/masterzen/winrm"
+)
+
+func main() {
+	endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	client, err := winrm.NewClient(endpoint, "Administrator", "secret")
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+### NTLM authentication (without encryption)
+
+Use `ClientNTLM` via the `TransportDecorator`. This requires `AllowUnencrypted="true"` on the server:
+
+```go
+endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+
+params := winrm.DefaultParameters
+params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
+
+client, err := winrm.NewClientWithParameters(endpoint, "Administrator", "secret", params)
 if err != nil {
 	panic(err)
 }
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
 client.RunWithContext(ctx, "ipconfig /all", os.Stdout, os.Stderr)
 ```
 
-or
-```go
-package main
-import (
-  "github.com/masterzen/winrm"
-  "fmt"
-  "os"
-)
+### NTLM authentication with encryption (recommended)
 
+Use `NewClientNTLMEncrypted()` for NTLM with message-level encryption. This works with the **default Windows configuration** (`AllowUnencrypted=false`) and is the recommended approach:
+
+```go
 endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
-client, err := winrm.NewClient(endpoint,"Administrator", "secret")
-if err != nil {
-	panic(err)
-}
-
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
-_, err := client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
-if err != nil {
-	panic(err)
-}
-
-```
-
-By passing a TransportDecorator in the Parameters struct it is possible to use different Transports (e.g. NTLM)
-
-```go
-package main
-import (
-  "github.com/masterzen/winrm"
-  "fmt"
-  "os"
-)
-
-endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
-
-params := DefaultParameters
-params.TransportDecorator = func() Transporter { return &ClientNTLM{} }
-
-client, err := NewClientWithParameters(endpoint, "test", "test", params)
-if err != nil {
-	panic(err)
-}
-
-_, err := client.RunWithInput("ipconfig", os.Stdout, os.Stderr, os.Stdin)
-if err != nil {
-	panic(err)
-}
-
-```
-
-Passing a TransportDecorator also permit to use Kerberos authentication
-
-```go
-package main
-import (
-  "os"
-  "fmt"
-  "github.com/masterzen/winrm"
-)
-
-endpoint := winrm.NewEndpoint("srv-win", 5985, false, false, nil, nil, nil, 0)
 
 params := winrm.DefaultParameters
-params.TransportDecorator = func() Transporter {
-        return &winrm.ClientKerberos{
-		Username: "test",
-		Password: "s3cr3t",
-		Hostname: "srv-win",
-		Realm: "DOMAIN.LAN",
-		Port: 5985,
-		Proto: "http",
-		KrbConf: "/etc/krb5.conf",
-		SPN: fmt.Sprintf("HTTP/%s", hostname),
-	}
-}
+params.TransportDecorator = func() winrm.Transporter { return winrm.NewClientNTLMEncrypted() }
 
-client, err := NewClientWithParameters(endpoint, "test", "s3cr3t", params)
+client, err := winrm.NewClientWithParameters(endpoint, "Administrator", "secret", params)
 if err != nil {
-        panic(err)
+	panic(err)
 }
-
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
-_, err := client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
-if err != nil {
-        panic(err)
-}
-
+client.RunWithContext(ctx, "ipconfig /all", os.Stdout, os.Stderr)
 ```
 
+Domain users are supported via `DOMAIN\user` or `user@domain` formats:
 
-By passing a Dial in the Parameters struct it is possible to use different dialer (e.g. tunnel through SSH)
+```go
+client, err := winrm.NewClientWithParameters(endpoint, `MYDOMAIN\admin`, "secret", params)
+// or
+client, err := winrm.NewClientWithParameters(endpoint, "admin@mydomain.com", "secret", params)
+```
+
+The `NewEncryption("ntlm")` API is also available for backwards compatibility:
+
+```go
+params.TransportDecorator = func() winrm.Transporter {
+	enc, _ := winrm.NewEncryption("ntlm")
+	return enc
+}
+```
+
+### Kerberos authentication
 
 ```go
 package main
-     
- import (
-    "github.com/masterzen/winrm"
-    "golang.org/x/crypto/ssh"
-    "os"
- )
- 
- func main() {
- 
-    sshClient, err := ssh.Dial("tcp","localhost:22", &ssh.ClientConfig{
-        User:"ubuntu",
-        Auth: []ssh.AuthMethod{ssh.Password("ubuntu")},
-        HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-    })
- 
-    endpoint := winrm.NewEndpoint("other-host", 5985, false, false, nil, nil, nil, 0)
- 
-    params := winrm.DefaultParameters
-    params.Dial = sshClient.Dial
- 
-    client, err := winrm.NewClientWithParameters(endpoint, "test", "test", params)
-    if err != nil {
-        panic(err)
-    }
- 
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    _, err = client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
-    if err != nil {
-        panic(err)
-    }
- }
 
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/masterzen/winrm"
+)
+
+func main() {
+	endpoint := winrm.NewEndpoint("srv-win", 5985, false, false, nil, nil, nil, 0)
+
+	params := winrm.DefaultParameters
+	params.TransportDecorator = func() winrm.Transporter {
+		return &winrm.ClientKerberos{
+			Username: "test",
+			Password: "s3cr3t",
+			Hostname: "srv-win",
+			Realm:    "DOMAIN.LAN",
+			Port:     5985,
+			Proto:    "http",
+			KrbConf:  "/etc/krb5.conf",
+			SPN:      fmt.Sprintf("HTTP/%s", "srv-win"),
+		}
+	}
+
+	client, err := winrm.NewClientWithParameters(endpoint, "test", "s3cr3t", params)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+}
 ```
 
+### Custom dialer (e.g. tunnel through SSH)
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/masterzen/winrm"
+	"golang.org/x/crypto/ssh"
+)
+
+func main() {
+	sshClient, err := ssh.Dial("tcp", "localhost:22", &ssh.ClientConfig{
+		User:            "ubuntu",
+		Auth:            []ssh.AuthMethod{ssh.Password("ubuntu")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	endpoint := winrm.NewEndpoint("other-host", 5985, false, false, nil, nil, nil, 0)
+
+	params := winrm.DefaultParameters
+	params.Dial = sshClient.Dial
+
+	client, err := winrm.NewClientWithParameters(endpoint, "test", "test", params)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = client.RunWithContextWithInput(ctx, "ipconfig", os.Stdout, os.Stderr, os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+
+### Shell API (advanced)
 
 For a more complex example, it is possible to call the various functions directly:
 
@@ -238,84 +283,90 @@ For a more complex example, it is possible to call the various functions directl
 package main
 
 import (
-  "github.com/masterzen/winrm"
-  "fmt"
-  "bytes"
-  "os"
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/masterzen/winrm"
 )
 
-stdin := bytes.NewBufferString("ipconfig /all")
-endpoint := winrm.NewEndpoint("localhost", 5985, false, false,nil, nil, nil, 0)
-client , err := winrm.NewClient(endpoint, "Administrator", "secret")
-if err != nil {
-	panic(err)
-}
-shell, err := client.CreateShell()
-if err != nil {
-  panic(err)
-}
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
-var cmd *winrm.Command
-cmd, err = shell.ExecuteWithContext(ctx, "cmd.exe")
-if err != nil {
-  panic(err)
-}
+func main() {
+	stdin := bytes.NewBufferString("ipconfig /all")
+	endpoint := winrm.NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	client, err := winrm.NewClient(endpoint, "Administrator", "secret")
+	if err != nil {
+		panic(err)
+	}
+	shell, err := client.CreateShell()
+	if err != nil {
+		panic(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var cmd *winrm.Command
+	cmd, err = shell.ExecuteWithContext(ctx, "cmd.exe")
+	if err != nil {
+		panic(err)
+	}
 
-go io.Copy(cmd.Stdin, stdin)
-go io.Copy(os.Stdout, cmd.Stdout)
-go io.Copy(os.Stderr, cmd.Stderr)
+	go io.Copy(cmd.Stdin, stdin)
+	go io.Copy(os.Stdout, cmd.Stdout)
+	go io.Copy(os.Stderr, cmd.Stderr)
 
-cmd.Wait()
-shell.Close()
+	cmd.Wait()
+	shell.Close()
+}
 ```
 
-For using HTTPS authentication with x 509 cert without checking the CA
+### HTTPS with certificate authentication
+
 ```go
 package main
 
 import (
-    "github.com/masterzen/winrm"
-    "log"
-    "os"
+	"context"
+	"log"
+	"os"
+
+	"github.com/masterzen/winrm"
 )
 
 func main() {
-    clientCert, err := os.ReadFile("/home/example/winrm_client_cert.pem")
-    if err != nil {
-        log.Fatalf("failed to read client certificate: %q", err)
-    }
+	clientCert, err := os.ReadFile("/home/example/winrm_client_cert.pem")
+	if err != nil {
+		log.Fatalf("failed to read client certificate: %q", err)
+	}
 
-    clientKey, err := os.ReadFile("/home/example/winrm_client_key.pem")
-    if err != nil {
-        log.Fatalf("failed to read client key: %q", err)
-    }
+	clientKey, err := os.ReadFile("/home/example/winrm_client_key.pem")
+	if err != nil {
+		log.Fatalf("failed to read client key: %q", err)
+	}
 
-    winrm.DefaultParameters.TransportDecorator = func() winrm.Transporter {
-        // winrm https module
-        return &winrm.ClientAuthRequest{}
-    }
+	winrm.DefaultParameters.TransportDecorator = func() winrm.Transporter {
+		// winrm https module
+		return &winrm.ClientAuthRequest{}
+	}
 
-    endpoint := winrm.NewEndpoint(
-        "192.168.100.2", // host to connect to
-        5986,            // winrm port
-        true,            // use TLS
-        true,            // Allow insecure connection
-        nil,             // CA certificate
-        clientCert,      // Client Certificate
-        clientKey,       // Client Key
-        0,               // Timeout
-    )
-    client, err := winrm.NewClient(endpoint, "Administrator", "")
-    if err != nil {
-        log.Fatalf("failed to create client: %q", err)
-    }
-    ctx, cancel := context.WithCancel(context.Background())
-    defer cancel()
-    _, err = client.RunWithContext(ctx, "whoami", os.Stdout, os.Stderr)
-    if err != nil {
-        log.Fatalf("failed to run command: %q", err)
-    }
+	endpoint := winrm.NewEndpoint(
+		"192.168.100.2", // host to connect to
+		5986,            // winrm port
+		true,            // use TLS
+		true,            // Allow insecure connection
+		nil,             // CA certificate
+		clientCert,      // Client Certificate
+		clientKey,       // Client Key
+		0,               // Timeout
+	)
+	client, err := winrm.NewClient(endpoint, "Administrator", "")
+	if err != nil {
+		log.Fatalf("failed to create client: %q", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = client.RunWithContext(ctx, "whoami", os.Stdout, os.Stderr)
+	if err != nil {
+		log.Fatalf("failed to run command: %q", err)
+	}
 }
 ```
 
@@ -327,15 +378,10 @@ rather cause a running command to be aborted on the remote machine via a call to
 ## Developing on WinRM
 
 If you wish to work on `winrm` itself, you'll first need [Go](http://golang.org)
-installed (version 1.5+ is _required_). Make sure you have Go properly installed,
+installed (version 1.21+ is _required_). Make sure you have Go properly installed,
 including setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH).
 
-For some additional dependencies, Go needs [Mercurial](http://mercurial.selenic.com/)
-and [Bazaar](http://bazaar.canonical.com/en/) to be installed.
-Winrm itself doesn't require these, but a dependency of a dependency does.
-
-Next, clone this repository into `$GOPATH/src/github.com/masterzen/winrm` and
-then just type `make`.
+Next, clone this repository and then just type `make`.
 
 You can run tests by typing `make test`.
 

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,664 @@
+This file contains the licenses for third-party dependencies used by this
+project that were introduced as part of the NTLM authentication changes
+(replacing Azure/go-ntlmssp with bodgit/ntlmssp).
+
+================================================================================
+github.com/bodgit/ntlmssp
+================================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2019, Matt Dainty
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+github.com/bodgit/windows
+================================================================================
+
+BSD 3-Clause License
+
+Copyright (c) 2020, Matt Dainty
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+github.com/tidwall/transform
+================================================================================
+
+ISC License
+
+Copyright (c) 2017, Joshua J Baker
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+================================================================================
+github.com/hashicorp/go-cleanhttp
+================================================================================
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+
+================================================================================
+github.com/go-logr/logr
+================================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/encryption.go
+++ b/encryption.go
@@ -1,438 +1,52 @@
 package winrm
 
 import (
-	"bytes"
-	"encoding/binary"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 
-	"github.com/bodgit/ntlmssp"
-	ntlmhttp "github.com/bodgit/ntlmssp/http"
 	"github.com/masterzen/winrm/soap"
 )
 
+// Encryption provides a transport that uses NTLM authentication with
+// message-level encryption (sealing). This works with the default Windows
+// AllowUnencrypted=false setting.
+//
+// It delegates to ClientNTLM with encryption enabled, which uses
+// bodgit/ntlmssp for both the NTLM handshake and message sealing/unsealing.
+//
+// Currently only the "ntlm" protocol is supported. CredSSP and Kerberos
+// encryption are not yet implemented.
 type Encryption struct {
-	ntlm           *ClientNTLM
-	protocol       string
-	protocolString []byte
-	httpClient     *http.Client
-	ntlmClient     *ntlmssp.Client
-	ntlmhttp       *ntlmhttp.Client
+	ntlm     *ClientNTLM
+	protocol string
 }
 
-const (
-	sixTenKB       = 16384
-	mimeBoundary   = "--Encrypted Boundary"
-	defaultCipher  = "RC4-HMAC-NTLM"
-	boundaryLength = len(mimeBoundary)
-)
-
-/*
-Encrypted Message Types
-When using Encryption, there are three options available
-
- 1. Negotiate/SPNEGO
-
- 2. Kerberos
-
- 3. CredSSP
-
-    protocol: The protocol string used for the particular auth protocol
-
-    The auth protocol used, will determine the wrapping and unwrapping method plus
-    the protocol string to use. Currently only NTLM is supported
-
-    based on the python code from https://pypi.org/project/pywinrm/
-
-    see https://github.com/diyan/pywinrm/blob/master/winrm/encryption.py
-
-    uses the most excellent NTLM library from https://github.com/bodgit/ntlmssp
-*/
+// NewEncryption creates a new Encryption transport for the given protocol.
+// Currently only "ntlm" is supported.
+//
+// Usage:
+//
+//	params.TransportDecorator = func() Transporter {
+//	    enc, _ := NewEncryption("ntlm")
+//	    return enc
+//	}
 func NewEncryption(protocol string) (*Encryption, error) {
-	encryption := &Encryption{
-		ntlm:     &ClientNTLM{},
-		protocol: protocol,
-	}
-
 	switch protocol {
 	case "ntlm":
-		encryption.protocolString = []byte("application/HTTP-SPNEGO-session-encrypted")
-		return encryption, nil
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			encryption.protocolString = []byte("application/HTTP-CredSSP-session-encrypted")
-		case "kerberos": // kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-			encryption.protocolString = []byte("application/HTTP-SPNEGO-session-encrypted")
-		*/
+		return &Encryption{
+			ntlm:     &ClientNTLM{useEncryption: true},
+			protocol: protocol,
+		}, nil
 	}
 
-	return nil, fmt.Errorf("Encryption for protocol '%s' not supported", protocol)
+	return nil, fmt.Errorf("encryption for protocol '%s' not supported", protocol)
 }
 
+// Transport sets up the underlying HTTP transport.
 func (e *Encryption) Transport(endpoint *Endpoint) error {
-	e.httpClient = &http.Client{}
 	return e.ntlm.Transport(endpoint)
 }
 
+// Post sends a SOAP message with NTLM encryption.
 func (e *Encryption) Post(client *Client, message *soap.SoapMessage) (string, error) {
-	var userName, domain string
-	if strings.Contains(client.username, "@") {
-		parts := strings.Split(client.username, "@")
-		domain = parts[1]
-		userName = parts[0]
-	} else if strings.Contains(client.username, "\\") {
-		parts := strings.Split(client.username, "\\")
-		domain = parts[0]
-		userName = parts[1]
-	} else {
-		userName = client.username
-	}
-
-	e.ntlmClient, _ = ntlmssp.NewClient(ntlmssp.SetUserInfo(userName, client.password), ntlmssp.SetDomain(domain), ntlmssp.SetVersion(ntlmssp.DefaultVersion()))
-	e.ntlmhttp, _ = ntlmhttp.NewClient(e.httpClient, e.ntlmClient)
-
-	var err error
-	if err = e.PrepareRequest(client, client.url); err == nil {
-		return e.PrepareEncryptedRequest(client, client.url, []byte(message.String()))
-	} else {
-		return e.ntlm.Post(client, message)
-	}
+	return e.ntlm.Post(client, message)
 }
-
-func (e *Encryption) PrepareRequest(client *Client, endpoint string) error {
-	req, err := http.NewRequest("POST", endpoint, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("User-Agent", "WinRM client")
-	req.Header.Set("Content-Length", "0")
-	req.Header.Set("Content-Type", "application/soap+xml;charset=UTF-8")
-	req.Header.Set("Connection", "Keep-Alive")
-
-	resp, err := e.ntlmhttp.Do(req)
-	if err != nil {
-		return fmt.Errorf("unknown error %w", err)
-	}
-
-	if _, err := io.ReadAll(resp.Body); err != nil {
-		return fmt.Errorf("read response body: %w", err)
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return fmt.Errorf("close request body: %w", err)
-	}
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("http error %d", resp.StatusCode)
-	}
-
-	return nil
-}
-
-/*
-Creates a prepared request to send to the server with an encrypted message
-and correct headers
-
-:param endpoint: The endpoint/server to prepare requests to
-:param message: The unencrypted message to send to the server
-:return: A prepared request that has an decrypted message
-*/
-func (e *Encryption) PrepareEncryptedRequest(client *Client, endpoint string, message []byte) (string, error) {
-	url, err := url.Parse(endpoint)
-	if err != nil {
-		return "", err
-	}
-	host := strings.Split(url.Hostname(), ":")[0]
-
-	var content_type string
-	var encrypted_message []byte
-
-	if e.protocol == "credssp" && len(message) > sixTenKB {
-		content_type = "multipart/x-multi-encrypted"
-		encrypted_message = []byte{}
-		message_chunks := [][]byte{}
-		for i := 0; i < len(message); i += sixTenKB {
-			message_chunks = append(message_chunks, message[i:i+sixTenKB])
-		}
-		for _, message_chunk := range message_chunks {
-			encrypted_chunk := e.encryptMessage(message_chunk, host)
-			encrypted_message = append(encrypted_message, encrypted_chunk...)
-		}
-	} else {
-		content_type = "multipart/encrypted"
-		encrypted_message = e.encryptMessage(message, host)
-	}
-
-	encrypted_message = append(encrypted_message, []byte(mimeBoundary)...)
-	encrypted_message = append(encrypted_message, []byte("--\r\n")...)
-
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(encrypted_message))
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Set("User-Agent", "WinRM client")
-	req.Header.Set("Connection", "Keep-Alive")
-	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(encrypted_message)))
-	req.Header.Set("Content-Type", fmt.Sprintf(`%s;protocol="%s";boundary="Encrypted Boundary"`, content_type, e.protocolString))
-
-	resp, err := e.ntlmhttp.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("unknown error %w", err)
-	}
-
-	body, err := e.ParseEncryptedResponse(resp)
-
-	return string(body), err
-}
-
-/*
-Takes in the encrypted response from the server and decrypts it
-
-:param response: The response that needs to be decrytped
-:return: The unencrypted message from the server
-*/
-func (e *Encryption) ParseEncryptedResponse(response *http.Response) ([]byte, error) {
-	contentType := response.Header.Get("Content-Type")
-	if strings.Contains(contentType, fmt.Sprintf(`protocol="%s"`, e.protocolString)) {
-		return e.decryptResponse(response, response.Request.URL.Hostname())
-	}
-	body, err := io.ReadAll(response.Body)
-	response.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
-}
-
-func (e *Encryption) encryptMessage(message []byte, host string) []byte {
-	encryptedStream, _ := e.buildMessage(message, host)
-
-	messagePayload := bytes.Join([][]byte{
-		[]byte(mimeBoundary),
-		[]byte("\r\n"),
-		[]byte(fmt.Sprintf("\tContent-Type: %s\r\n", string(e.protocolString))),
-		[]byte(fmt.Sprintf("\tOriginalContent: type=application/soap+xml;charset=UTF-8;Length=%d\r\n", len(message))),
-		[]byte(mimeBoundary),
-		[]byte("\r\n"),
-		[]byte("\tContent-Type: application/octet-stream\r\n"),
-		encryptedStream,
-	}, []byte{})
-
-	return messagePayload
-}
-
-func deleteEmpty(b [][]byte) [][]byte {
-	var r [][]byte
-	for _, by := range b {
-		if len(by) != 0 {
-			r = append(r, by)
-		}
-	}
-	return r
-}
-
-// tried using pkg.go.dev/mime/multipart here but parsing fails with with
-// because in the header we have "\tContent-Type: application/HTTP-SPNEGO-session-encrypted\r\n"
-// on call to textproto.ReadMIMEHeader
-// because of "The first line cannot start with a leading space."
-func (e *Encryption) decryptResponse(response *http.Response, host string) ([]byte, error) {
-	body, _ := io.ReadAll(response.Body)
-	parts := deleteEmpty(bytes.Split(body, []byte(fmt.Sprintf("%s\r\n", mimeBoundary))))
-	var message []byte
-
-	for i := 0; i < len(parts); i += 2 {
-		header := parts[i]
-		payload := parts[i+1]
-
-		expectedLengthStr := bytes.SplitAfter(header, []byte("Length="))[1]
-		expectedLength, err := strconv.Atoi(string(bytes.TrimSpace(expectedLengthStr)))
-		if err != nil {
-			return nil, err
-		}
-
-		// remove the end MIME block if it exists
-		if bytes.HasSuffix(payload, []byte(fmt.Sprintf("%s--\r\n", mimeBoundary))) {
-			payload = payload[:len(payload)-boundaryLength-4]
-		}
-		encryptedData := bytes.ReplaceAll(payload, []byte("\tContent-Type: application/octet-stream\r\n"), []byte{})
-		decryptedMessage, err := e.decryptMessage(encryptedData, host)
-		if err != nil {
-			return nil, err
-		}
-
-		actualLength := int(len(decryptedMessage))
-		if actualLength != expectedLength {
-			return nil, errors.New("encrypted length from server does not match the expected size, message has been tampered with")
-		}
-
-		message = append(message, decryptedMessage...)
-	}
-
-	return message, nil
-}
-
-func (e *Encryption) decryptMessage(encryptedData []byte, host string) ([]byte, error) {
-	switch e.protocol {
-	case "ntlm":
-		return e.decryptNtlmMessage(encryptedData, host)
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			return e.decryptCredsspMessage(encryptedData, host)
-		case "kerberos":
-			return e.decryptKerberosMessage(encryptedData, host)
-		*/
-	default:
-		return nil, errors.New("Encryption for protocol " + e.protocol + " not supported")
-	}
-}
-
-func (e *Encryption) decryptNtlmMessage(encryptedData []byte, host string) ([]byte, error) {
-	signatureLength := int(binary.LittleEndian.Uint32(encryptedData[:4]))
-	signature := encryptedData[4 : signatureLength+4]
-	encryptedMessage := encryptedData[signatureLength+4:]
-
-	message, err := e.ntlmClient.SecuritySession().Unwrap(encryptedMessage, signature)
-	if err != nil {
-		return nil, err
-	}
-	return message, nil
-}
-
-/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-func (e *Encryption) decryptCredsspMessage(encryptedData []byte, host string) ([]byte, error) {
-	// // TODO
-	// encryptedMessage := encryptedData[4:]
-
-	// credsspContext, ok := e.session.Auth.Contexts()[host]
-	// if !ok {
-	// 	return nil, fmt.Errorf("credssp context not found for host: %s", host)
-	// }
-
-	// message, err := credsspContext.Unwrap(encryptedMessage)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// return message, nil
-}
-
-func (enc *Encryption) decryptKerberosMessage(encryptedData []byte, host string) ([]byte, error) {
-	// //TODO
-	// signatureLength := binary.LittleEndian.Uint32(encryptedData[0:4])
-	// signature := encryptedData[4 : 4+signatureLength]
-	// encryptedMessage := encryptedData[4+signatureLength:]
-
-	// message, err := enc.session.Auth.UnwrapWinrm(host, encryptedMessage, signature)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return message, nil
-}
-*/
-
-func (e *Encryption) buildMessage(encryptedData []byte, host string) ([]byte, error) {
-	switch e.protocol {
-	case "ntlm":
-		return e.buildNTLMMessage(encryptedData, host)
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			return e.buildCredSSPMessage(encryptedData, host)
-		case "kerberos":
-			return e.buildKerberosMessage(encryptedData, host)
-		*/
-	default:
-		return nil, errors.New("Encryption for protocol " + e.protocol + " not supported")
-	}
-}
-
-func (enc *Encryption) buildNTLMMessage(message []byte, host string) ([]byte, error) {
-	if enc.ntlmClient.SecuritySession() == nil {
-		return nil, nil
-	}
-	sealedMessage, signature, err := enc.ntlmClient.SecuritySession().Wrap(message)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := new(bytes.Buffer)
-	if err = binary.Write(buf, binary.LittleEndian, uint32(len(signature))); err != nil {
-		return nil, err
-	}
-
-	buf.Write(signature)
-	buf.Write(sealedMessage)
-
-	return buf.Bytes(), nil
-}
-
-/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-func (e *Encryption) buildCredSSPMessage(message []byte, host string) ([]byte, error) {
-	// //TODO
-	// context := e.session.Auth.Contexts[host]
-	// sealedMessage := context.Wrap(message)
-
-	// cipherNegotiated := context.TLSConnection.ConnectionState().CipherSuite.Name
-	// trailerLength := e.getCredSSPTrailerLength(len(message), cipherNegotiated)
-
-	// trailer := make([]byte, 4)
-	// binary.LittleEndian.PutUint32(trailer, uint32(trailerLength))
-
-	// return append(trailer, sealedMessage...), nil
-}
-
-func (e *Encryption) buildKerberosMessage(message []byte, host string) ([]byte, error) {
-	// //TODO
-	// sealedMessage, signature := e.session.Auth.WrapWinrm(host, message)
-
-	// signatureLength := make([]byte, 4)
-	// binary.LittleEndian.PutUint32(signatureLength, uint32(len(signature)))
-
-	// return append(append(signatureLength, signature...), sealedMessage...), nil
-}
-
-func (e *Encryption) getCredSSPTrailerLength(messageLength int, cipherSuite string) int {
-	var trailerLength int
-
-	if match, _ := regexp.MatchString("^.*-GCM-[\\w\\d]*$", cipherSuite); match {
-		trailerLength = 16
-	} else {
-		hashAlgorithm := cipherSuite[strings.LastIndex(cipherSuite, "-")+1:]
-		var hashLength int
-
-		if hashAlgorithm == "MD5" {
-			hashLength = 16
-		} else if hashAlgorithm == "SHA" {
-			hashLength = 20
-		} else if hashAlgorithm == "SHA256" {
-			hashLength = 32
-		} else if hashAlgorithm == "SHA384" {
-			hashLength = 48
-		} else {
-			hashLength = 0
-		}
-
-		prePadLength := messageLength + hashLength
-		paddingLength := 0
-
-		if strings.Contains(cipherSuite, "RC4") {
-			paddingLength = 0
-		} else if strings.Contains(cipherSuite, "DES") || strings.Contains(cipherSuite, "3DES") {
-			paddingLength = 8 - (prePadLength % 8)
-
-		} else {
-			// AES is a 128 bit block cipher
-			paddingLength = 16 - (prePadLength % 16)
-		}
-
-		trailerLength = (prePadLength + paddingLength) - messageLength
-	}
-	return trailerLength
-}
-*/

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/masterzen/winrm
 go 1.21
 
 require (
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6
 	github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6 h1:w0E0fgc1YafGEh5cROhlROMWXiNoZqApk2PDN0M1+Ns=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b h1:baFN6AnR0SeC194X2D292IUZcHDs4JjStpqtE70fjXE=

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,6 +1,7 @@
 package winrm
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -75,7 +76,7 @@ func (c *ClientNTLM) ensureSession(client *Client) error {
 		return fmt.Errorf("failed to create NTLM client: %w", err)
 	}
 
-	httpClient := &http.Client{Transport: c.clientRequest.transport}
+	httpClient := &http.Client{Transport: c.transport}
 
 	var opts []func(*ntlmhttp.Client) error
 	if c.useEncryption {
@@ -113,7 +114,7 @@ func (c *ClientNTLM) ensureSession(client *Client) error {
 // POST request. After this completes, the security session is established
 // and can be used for message sealing/unsealing.
 func (c *ClientNTLM) doAuthHandshake(client *Client) error {
-	req, err := http.NewRequest("POST", client.url, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", client.url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create auth request: %w", err)
 	}
@@ -125,10 +126,11 @@ func (c *ClientNTLM) doAuthHandshake(client *Client) error {
 	if err != nil {
 		return fmt.Errorf("NTLM authentication failed: %w", err)
 	}
+	defer resp.Body.Close()
+
 	if _, err := io.ReadAll(resp.Body); err != nil {
 		return fmt.Errorf("read auth response body: %w", err)
 	}
-	resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("NTLM auth http error %d", resp.StatusCode)
@@ -140,7 +142,7 @@ func (c *ClientNTLM) doAuthHandshake(client *Client) error {
 // postPlain sends a SOAP request without message-level encryption.
 // The NTLM handshake happens transparently via bodgit's HTTP client.
 func (c *ClientNTLM) postPlain(client *Client, request *soap.SoapMessage) (string, error) {
-	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
+	req, err := http.NewRequestWithContext(context.Background(), "POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
 		return "", fmt.Errorf("impossible to create http request %w", err)
 	}
@@ -173,7 +175,7 @@ func (c *ClientNTLM) postPlain(client *Client, request *soap.SoapMessage) (strin
 // bodgit's HTTP client automatically wraps (seals) the request and
 // unwraps (unseals) the response.
 func (c *ClientNTLM) postEncrypted(client *Client, request *soap.SoapMessage) (string, error) {
-	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
+	req, err := http.NewRequestWithContext(context.Background(), "POST", client.url, strings.NewReader(request.String()))
 	if err != nil {
 		return "", fmt.Errorf("failed to create SOAP request: %w", err)
 	}

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,47 +1,257 @@
 package winrm
 
 import (
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 
-	"github.com/Azure/go-ntlmssp"
+	"github.com/bodgit/ntlmssp"
+	ntlmhttp "github.com/bodgit/ntlmssp/http"
 	"github.com/masterzen/winrm/soap"
 )
 
-// ClientNTLM provides a transport via NTLMv2
+// ClientNTLM provides a transport via NTLMv2 using bodgit/ntlmssp.
+// When useEncryption is true, SOAP messages are sealed (encrypted) using
+// the NTLM security session, which works with the default Windows
+// AllowUnencrypted=false setting.
 type ClientNTLM struct {
 	clientRequest
+	useEncryption bool
+
+	// Cached session state — reused across Post() calls to avoid
+	// re-handshaking on every request. Protected by mu.
+	mu             sync.Mutex
+	ntlmClient     *ntlmssp.Client
+	ntlmHTTPClient *ntlmhttp.Client
+	cachedUser     string
+	cachedPass     string
+	sessionReady   bool // true after encrypted session handshake completes
 }
 
-// Transport creates the wrapped NTLM transport
+// Transport creates the base HTTP transport for NTLM connections.
 func (c *ClientNTLM) Transport(endpoint *Endpoint) error {
-	if err := c.clientRequest.Transport(endpoint); err != nil {
-		return err
+	return c.clientRequest.Transport(endpoint)
+}
+
+// Post sends a SOAP message to the WinRM service using NTLM authentication.
+// It reuses cached NTLM sessions when possible to avoid repeated handshakes.
+func (c *ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.ensureSession(client); err != nil {
+		return "", err
 	}
-	c.clientRequest.transport = &ntlmssp.Negotiator{RoundTripper: c.clientRequest.transport}
+
+	if c.useEncryption {
+		return c.postEncrypted(client, request)
+	}
+	return c.postPlain(client, request)
+}
+
+// ensureSession creates or reuses the bodgit NTLM client and HTTP client.
+// If credentials changed, the session is re-created.
+// For encrypted sessions, performs the initial auth handshake if needed.
+func (c *ClientNTLM) ensureSession(client *Client) error {
+	// Check if we need a fresh session (first call or credentials changed)
+	credentialsChanged := client.username != c.cachedUser || client.password != c.cachedPass
+
+	if c.ntlmHTTPClient != nil && !credentialsChanged {
+		return nil // reuse existing session
+	}
+
+	userName, domain := parseUsernameAndDomain(client.username)
+
+	ntlmClient, err := ntlmssp.NewClient(
+		ntlmssp.SetUserInfo(userName, client.password),
+		ntlmssp.SetDomain(domain),
+		ntlmssp.SetVersion(ntlmssp.DefaultVersion()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create NTLM client: %w", err)
+	}
+
+	httpClient := &http.Client{Transport: c.clientRequest.transport}
+
+	var opts []func(*ntlmhttp.Client) error
+	if c.useEncryption {
+		opts = append(opts, ntlmhttp.Encryption(true))
+	}
+
+	ntlmHTTPClient, err := ntlmhttp.NewClient(httpClient, ntlmClient, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create NTLM HTTP client: %w", err)
+	}
+
+	c.ntlmClient = ntlmClient
+	c.ntlmHTTPClient = ntlmHTTPClient
+	c.cachedUser = client.username
+	c.cachedPass = client.password
+	c.sessionReady = false
+
+	// For encrypted mode, establish the NTLM session immediately
+	// with an empty POST so the security session is ready for sealing.
+	if c.useEncryption {
+		if err := c.doAuthHandshake(client); err != nil {
+			// Reset session state on failure
+			c.ntlmHTTPClient = nil
+			c.ntlmClient = nil
+			c.sessionReady = false
+			return err
+		}
+		c.sessionReady = true
+	}
+
 	return nil
 }
 
-// Post make post to the winrm soap service (forwarded to clientRequest implementation)
-func (c ClientNTLM) Post(client *Client, request *soap.SoapMessage) (string, error) {
-	return c.clientRequest.Post(client, request)
+// doAuthHandshake performs the NTLM authentication handshake with an empty
+// POST request. After this completes, the security session is established
+// and can be used for message sealing/unsealing.
+func (c *ClientNTLM) doAuthHandshake(client *Client) error {
+	req, err := http.NewRequest("POST", client.url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create auth request: %w", err)
+	}
+	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
+	req.Header.Set("Content-Length", "0")
+	req.Header.Set("Connection", "Keep-Alive")
+
+	resp, err := c.ntlmHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("NTLM authentication failed: %w", err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return fmt.Errorf("read auth response body: %w", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("NTLM auth http error %d", resp.StatusCode)
+	}
+
+	return nil
 }
 
-//NewClientNTLMWithDial NewClientNTLMWithDial
+// postPlain sends a SOAP request without message-level encryption.
+// The NTLM handshake happens transparently via bodgit's HTTP client.
+func (c *ClientNTLM) postPlain(client *Client, request *soap.SoapMessage) (string, error) {
+	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
+	if err != nil {
+		return "", fmt.Errorf("impossible to create http request %w", err)
+	}
+	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
+
+	resp, err := c.ntlmHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("unknown error %w", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("http error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if !strings.Contains(resp.Header.Get("Content-Type"), "application/soap+xml") {
+		return "", fmt.Errorf("invalid content type")
+	}
+
+	return string(respBody), nil
+}
+
+// postEncrypted sends a SOAP request with NTLM message-level encryption.
+// The NTLM session must already be established via doAuthHandshake().
+// bodgit's HTTP client automatically wraps (seals) the request and
+// unwraps (unseals) the response.
+func (c *ClientNTLM) postEncrypted(client *Client, request *soap.SoapMessage) (string, error) {
+	req, err := http.NewRequest("POST", client.url, strings.NewReader(request.String()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create SOAP request: %w", err)
+	}
+	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
+	req.Header.Set("Connection", "Keep-Alive")
+
+	resp, err := c.ntlmHTTPClient.Do(req)
+	if err != nil {
+		// Session may have expired — reset and let next call re-establish
+		c.ntlmHTTPClient = nil
+		c.sessionReady = false
+		return "", fmt.Errorf("encrypted request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("http error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return string(respBody), nil
+}
+
+// NewClientNTLMWithDial creates a new NTLM transport with a custom dialer.
 func NewClientNTLMWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
 	return &ClientNTLM{
-		clientRequest{
+		clientRequest: clientRequest{
 			dial: dial,
 		},
 	}
 }
 
-//NewClientNTLMWithProxyFunc NewClientNTLMWithProxyFunc
+// NewClientNTLMWithProxyFunc creates a new NTLM transport with a custom proxy function.
 func NewClientNTLMWithProxyFunc(proxyfunc func(req *http.Request) (*url.URL, error)) *ClientNTLM {
 	return &ClientNTLM{
-		clientRequest{
+		clientRequest: clientRequest{
 			proxyfunc: proxyfunc,
 		},
 	}
+}
+
+// NewClientNTLMEncrypted creates an NTLM transport with message encryption (sealing).
+// This works with the default Windows AllowUnencrypted=false setting.
+func NewClientNTLMEncrypted() *ClientNTLM {
+	return &ClientNTLM{useEncryption: true}
+}
+
+// NewClientNTLMEncryptedWithDial creates an encrypted NTLM transport with a custom dialer.
+func NewClientNTLMEncryptedWithDial(dial func(network, addr string) (net.Conn, error)) *ClientNTLM {
+	return &ClientNTLM{
+		clientRequest: clientRequest{dial: dial},
+		useEncryption: true,
+	}
+}
+
+// NewClientNTLMEncryptedWithProxyFunc creates an encrypted NTLM transport with a custom proxy function.
+func NewClientNTLMEncryptedWithProxyFunc(proxyfunc func(req *http.Request) (*url.URL, error)) *ClientNTLM {
+	return &ClientNTLM{
+		clientRequest: clientRequest{proxyfunc: proxyfunc},
+		useEncryption: true,
+	}
+}
+
+// parseUsernameAndDomain extracts the username and domain from various formats:
+//   - "DOMAIN\user" -> user, DOMAIN
+//   - "user@domain.com" -> user, domain.com
+//   - "user" -> user, ""
+func parseUsernameAndDomain(username string) (string, string) {
+	if strings.Contains(username, "@") {
+		parts := strings.Split(username, "@")
+		return parts[0], parts[1]
+	} else if strings.Contains(username, "\\") {
+		parts := strings.Split(username, "\\")
+		return parts[1], parts[0]
+	}
+	return username, ""
 }

--- a/ntlm_test.go
+++ b/ntlm_test.go
@@ -55,3 +55,67 @@ func (s *WinRMSuite) TestHttpNTLMViaCustomDialerRequest(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(usedCustomDialer, Equals, true)
 }
+
+func (s *WinRMSuite) TestParseUsernameAndDomainBackslash(c *C) {
+	user, domain := parseUsernameAndDomain(`MYDOMAIN\admin`)
+	c.Assert(user, Equals, "admin")
+	c.Assert(domain, Equals, "MYDOMAIN")
+}
+
+func (s *WinRMSuite) TestParseUsernameAndDomainAtSign(c *C) {
+	user, domain := parseUsernameAndDomain("admin@corp.example.com")
+	c.Assert(user, Equals, "admin")
+	c.Assert(domain, Equals, "corp.example.com")
+}
+
+func (s *WinRMSuite) TestParseUsernameAndDomainPlain(c *C) {
+	user, domain := parseUsernameAndDomain("admin")
+	c.Assert(user, Equals, "admin")
+	c.Assert(domain, Equals, "")
+}
+
+func (s *WinRMSuite) TestNewEncryptionNTLM(c *C) {
+	enc, err := NewEncryption("ntlm")
+	c.Assert(err, IsNil)
+	c.Assert(enc, NotNil)
+	c.Assert(enc.protocol, Equals, "ntlm")
+	c.Assert(enc.ntlm.useEncryption, Equals, true)
+}
+
+func (s *WinRMSuite) TestNewEncryptionUnsupportedProtocol(c *C) {
+	enc, err := NewEncryption("credssp")
+	c.Assert(err, NotNil)
+	c.Assert(enc, IsNil)
+	c.Assert(err, ErrorMatches, `encryption for protocol 'credssp' not supported`)
+}
+
+func (s *WinRMSuite) TestNewClientNTLMEncrypted(c *C) {
+	client := NewClientNTLMEncrypted()
+	c.Assert(client.useEncryption, Equals, true)
+}
+
+func (s *WinRMSuite) TestNewClientNTLMEncryptedWithDial(c *C) {
+	dial := func(network, addr string) (net.Conn, error) {
+		return nil, nil
+	}
+	client := NewClientNTLMEncryptedWithDial(dial)
+	c.Assert(client.useEncryption, Equals, true)
+	c.Assert(client.clientRequest.dial, NotNil)
+}
+
+func (s *WinRMSuite) TestNewClientNTLMEncryptedWithProxyFunc(c *C) {
+	proxy := http.ProxyFromEnvironment
+	client := NewClientNTLMEncryptedWithProxyFunc(proxy)
+	c.Assert(client.useEncryption, Equals, true)
+	c.Assert(client.clientRequest.proxyfunc, NotNil)
+}
+
+func (s *WinRMSuite) TestNTLMEncryptedViaEncryptionWrapper(c *C) {
+	// Verify that NewEncryption("ntlm") creates a transport with encryption enabled
+	enc, err := NewEncryption("ntlm")
+	c.Assert(err, IsNil)
+
+	endpoint := NewEndpoint("localhost", 5985, false, false, nil, nil, nil, 0)
+	err = enc.Transport(endpoint)
+	c.Assert(err, IsNil)
+}

--- a/ntlm_test.go
+++ b/ntlm_test.go
@@ -100,14 +100,14 @@ func (s *WinRMSuite) TestNewClientNTLMEncryptedWithDial(c *C) {
 	}
 	client := NewClientNTLMEncryptedWithDial(dial)
 	c.Assert(client.useEncryption, Equals, true)
-	c.Assert(client.clientRequest.dial, NotNil)
+	c.Assert(client.dial, NotNil)
 }
 
 func (s *WinRMSuite) TestNewClientNTLMEncryptedWithProxyFunc(c *C) {
 	proxy := http.ProxyFromEnvironment
 	client := NewClientNTLMEncryptedWithProxyFunc(proxy)
 	c.Assert(client.useEncryption, Equals, true)
-	c.Assert(client.clientRequest.proxyfunc, NotNil)
+	c.Assert(client.proxyfunc, NotNil)
 }
 
 func (s *WinRMSuite) TestNTLMEncryptedViaEncryptionWrapper(c *C) {


### PR DESCRIPTION
## Summary

- **Replace `Azure/go-ntlmssp` with `bodgit/ntlmssp`** — Azure's library doesn't support NTLM message sealing, which means `ClientNTLM` fails against any Windows host with the default `AllowUnencrypted=false` setting. `bodgit/ntlmssp` supports full NTLMv2 with sealing/signing via its `http` subpackage.
- **Add optional message-level encryption to `ClientNTLM`** — New `useEncryption` flag and constructors (`NewClientNTLMEncrypted()`, `NewClientNTLMEncryptedWithDial()`, `NewClientNTLMEncryptedWithProxyFunc()`) enable NTLM sealing without requiring `AllowUnencrypted=true` on the server.
- **Simplify `encryption.go` from ~440 lines to ~53 lines** — The old manual MIME multipart wrapping/unwrapping code is replaced by delegating entirely to `ClientNTLM{useEncryption: true}`, since bodgit's HTTP client handles sealed MIME envelopes automatically.

## What changed

| Before | After |
|--------|-------|
| `ClientNTLM` uses Azure/go-ntlmssp `Negotiator` | `ClientNTLM` uses bodgit/ntlmssp `http.Client` |
| No encryption support in `ClientNTLM` | Optional encryption via `useEncryption` flag |
| `encryption.go` manually wraps/unwraps MIME (~440 LOC) | `encryption.go` delegates to `ClientNTLM` (~53 LOC) |
| Two separate NTLM implementations | Single unified implementation |

## Files changed

- **`ntlm.go`** — Rewritten to use bodgit/ntlmssp. Added session caching (mutex-protected), credential change detection, auth handshake for encrypted mode, and new constructors.
- **`encryption.go`** — Simplified to a thin wrapper around `ClientNTLM{useEncryption: true}`.
- **`ntlm_test.go`** — Added 9 new tests: `parseUsernameAndDomain` (3 formats), `NewEncryption` (valid + unsupported), all new constructors, and `Encryption` wrapper.
- **`go.mod` / `go.sum`** — Removed `github.com/Azure/go-ntlmssp`.
- **`.golangci.yml`** — Migrated from v1 to v2 config format.
- **`README.md`** — Rewritten to document all auth methods including NTLM with encryption.
- **`THIRD_PARTY_LICENSES`** — Added full license texts for bodgit/ntlmssp (BSD 3-Clause) and transitive dependencies.

## Usage

### NTLM with encryption (recommended — works with default Windows config)
```go
params.TransportDecorator = func() Transporter { return NewClientNTLMEncrypted() }

### NTLM without encryption (requires AllowUnencrypted=true on server)
params.TransportDecorator = func() Transporter { return &ClientNTLM{} }

##Domain user formats (all supported)
**`DOMAIN\user`**
**`user@domain.com`**
**`user`**

##Test plan
 All existing tests pass (go test ./...)
 New unit tests for parseUsernameAndDomain, constructors, and encryption wrapper
 go vet clean
 golangci-lint clean (v2 config)
 Zero references to Azure/go-ntlmssp remaining in codebase
 Manual testing against a Windows host with AllowUnencrypted=false (default)