### PR TITLE
Add CredSSP authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ On the remote host, a PowerShell prompt, using the __Run as Administrator__ opti
 
 All __N.B__ points of "Preparing the remote Windows machine for Basic authentication" also applies.
 
+### Preparing the remote Windows machine for CredSSP authentication
+CredSSP requires both WinRM and CredSSP to be enabled on the target host.
+
+On the remote host, run PowerShell as Administrator and execute:
+
+                winrm quickconfig
+                Enable-WSManCredSSP -Role Server -Force
+                winrm set winrm/config/service/Auth '@{CredSSP="true"}'
+
+CredSSP wraps the WinRM payload in its own TLS-encrypted channel, so there is no need to enable `AllowUnencrypted` for this transport.
+
+To allow the client machine to delegate credentials to this host, configure the client policy or run:
+
+                Enable-WSManCredSSP -Role Client -DelegateComputer "<server-or-pattern>" -Force
+
+All __N.B__ points of "Preparing the remote Windows machine for Basic authentication" also apply.
+
 
 ### Building the winrm go and executable
 
@@ -190,6 +207,49 @@ if err != nil {
 }
 
 ```
+
+By passing a TransportDecorator it is also possible to use CredSSP authentication:
+
+```go
+package main
+
+import (
+  "context"
+  "os"
+
+  "github.com/masterzen/winrm"
+)
+
+endpoint := winrm.NewEndpoint("srv-win", 5985, false, true, nil, nil, nil, 0)
+
+params := winrm.DefaultParameters
+params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientCredSSP{} }
+
+client, err := winrm.NewClientWithParameters(endpoint, "DOMAIN\\user", "s3cr3t", params)
+if err != nil {
+  panic(err)
+}
+
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+_, err = client.RunWithContext(ctx, "whoami", os.Stdout, os.Stderr)
+if err != nil {
+  panic(err)
+}
+```
+
+__N.B.:__ CredSSP binds authentication state and its TLS tunnel to a single connection, so all requests on a CredSSP client are serialized. Because a long-polling output `Receive` holds that lock until it returns, concurrent stdin sends are stalled behind each poll. Real-time interactive stdin is therefore not supported over CredSSP; non-interactive `RunCmd`/`RunPS` (no stdin) are unaffected. If the server drops the pinned connection, the client transparently re-runs the handshake once on the next request.
+
+### Running opt-in CredSSP integration tests
+The CredSSP live integration test is disabled by default and only compiled when using the `credssp_integration` build tag.
+
+```bash
+WINRM_CREDSSP_HOST=win-host WINRM_CREDSSP_PORT=5985 \
+WINRM_CREDSSP_USER='DOMAIN\\user' WINRM_CREDSSP_PASSWORD=... \
+go test -tags credssp_integration -run CredSSPIntegration -v ./...
+```
+
+If the required environment variables are unset, the test will be skipped.
 
 
 By passing a Dial in the Parameters struct it is possible to use different dialer (e.g. tunnel through SSH)

--- a/credssp.go
+++ b/credssp.go
@@ -1,0 +1,858 @@
+package winrm
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bodgit/ntlmssp"
+	"github.com/masterzen/winrm/soap"
+)
+
+const (
+	credSSPHeaderName = "CredSSP"
+
+	// ntlmSignatureLength is the fixed size of an NTLM message signature
+	// (version + checksum + sequence number). MS-CSSP carries this raw
+	// signature immediately followed by the sealed data.
+	ntlmSignatureLength = 16
+
+	// defaultCredSSPTimeout bounds blocking waits when the caller supplied a
+	// zero (unbounded) endpoint timeout.
+	defaultCredSSPTimeout = 60 * time.Second
+
+	// credSSPHandshakeDrainSettle is the idle window used to coalesce a full TLS
+	// handshake flight (which crypto/tls may emit as several back-to-back
+	// writes) into a single CredSSP token exchange, avoiding a partial flight
+	// being POSTed on its own.
+	credSSPHandshakeDrainSettle = 20 * time.Millisecond
+
+	credSSPClientBindingLabel = "CredSSP Client-To-Server Binding Hash\x00"
+	credSSPServerBindingLabel = "CredSSP Server-To-Client Binding Hash\x00"
+)
+
+// credSSPTimeout returns a usable timeout, applying a sane floor when the
+// endpoint timeout is zero so that time.After does not fire immediately.
+func credSSPTimeout(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultCredSSPTimeout
+	}
+	return d
+}
+
+var (
+	errCredSSPClosed = errors.New("credssp connection is closed")
+
+	// errCredSSPReauthRequired signals that the server rejected an encrypted
+	// request as unauthenticated (HTTP 401), typically because the pinned
+	// connection was dropped and re-dialed. It triggers a one-shot re-handshake.
+	errCredSSPReauthRequired = errors.New("credssp re-authentication required")
+)
+
+type credSSPMemoryConn struct {
+	readMu   sync.Mutex
+	readBuf  bytes.Buffer
+	incoming chan []byte
+	outgoing chan []byte
+	closeCh  chan struct{}
+
+	deadlineMu   sync.Mutex
+	readDeadline time.Time
+}
+
+func newCredSSPMemoryConn() *credSSPMemoryConn {
+	return &credSSPMemoryConn{
+		incoming: make(chan []byte, 32),
+		outgoing: make(chan []byte, 32),
+		closeCh:  make(chan struct{}),
+	}
+}
+
+func (c *credSSPMemoryConn) Read(p []byte) (int, error) {
+	for {
+		c.readMu.Lock()
+		if c.readBuf.Len() > 0 {
+			n, _ := c.readBuf.Read(p)
+			c.readMu.Unlock()
+			return n, nil
+		}
+		c.readMu.Unlock()
+
+		// Honor the read deadline so a truncated server flight cannot block
+		// Read (and therefore readTSRequest / io.ReadFull) indefinitely.
+		var timeout <-chan time.Time
+		var timer *time.Timer
+		c.deadlineMu.Lock()
+		deadline := c.readDeadline
+		c.deadlineMu.Unlock()
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return 0, os.ErrDeadlineExceeded
+			}
+			timer = time.NewTimer(remaining)
+			timeout = timer.C
+		}
+
+		select {
+		case data, ok := <-c.incoming:
+			if timer != nil {
+				timer.Stop()
+			}
+			if !ok {
+				return 0, io.EOF
+			}
+			c.readMu.Lock()
+			c.readBuf.Write(data)
+			c.readMu.Unlock()
+		case <-c.closeCh:
+			if timer != nil {
+				timer.Stop()
+			}
+			return 0, io.EOF
+		case <-timeout:
+			return 0, os.ErrDeadlineExceeded
+		}
+	}
+}
+
+func (c *credSSPMemoryConn) Write(p []byte) (int, error) {
+	payload := append([]byte(nil), p...)
+	select {
+	case c.outgoing <- payload:
+		return len(p), nil
+	case <-c.closeCh:
+		return 0, errCredSSPClosed
+	}
+}
+
+func (c *credSSPMemoryConn) Close() error {
+	select {
+	case <-c.closeCh:
+	default:
+		close(c.closeCh)
+	}
+	return nil
+}
+
+func (c *credSSPMemoryConn) LocalAddr() net.Addr {
+	return dummyAddr("local")
+}
+
+func (c *credSSPMemoryConn) RemoteAddr() net.Addr {
+	return dummyAddr("remote")
+}
+
+func (c *credSSPMemoryConn) SetDeadline(t time.Time) error {
+	return c.SetReadDeadline(t)
+}
+
+func (c *credSSPMemoryConn) SetReadDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = t
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func (c *credSSPMemoryConn) SetWriteDeadline(_ time.Time) error {
+	return nil
+}
+
+func (c *credSSPMemoryConn) pushIncoming(payload []byte) error {
+	data := append([]byte(nil), payload...)
+	select {
+	case c.incoming <- data:
+		return nil
+	case <-c.closeCh:
+		return errCredSSPClosed
+	}
+}
+
+func (c *credSSPMemoryConn) popOutgoing(timeout time.Duration) ([]byte, error) {
+	select {
+	case payload := <-c.outgoing:
+		return payload, nil
+	case <-time.After(timeout):
+		return nil, errors.New("timed out waiting for outgoing TLS records")
+	case <-c.closeCh:
+		return nil, io.EOF
+	}
+}
+
+func (c *credSSPMemoryConn) drainOutgoing(first []byte) []byte {
+	payload := append([]byte(nil), first...)
+	for {
+		select {
+		case extra := <-c.outgoing:
+			payload = append(payload, extra...)
+		default:
+			return payload
+		}
+	}
+}
+
+// drainOutgoingWithin coalesces the first chunk with any further chunks that
+// arrive within the settle window. Unlike drainOutgoing (which returns as soon
+// as the channel is momentarily empty), this waits a short idle period so a
+// multi-write TLS flight produced by a concurrent handshake goroutine is not
+// split across separate CredSSP token exchanges.
+func (c *credSSPMemoryConn) drainOutgoingWithin(first []byte, settle time.Duration) []byte {
+	payload := append([]byte(nil), first...)
+	timer := time.NewTimer(settle)
+	defer timer.Stop()
+	for {
+		select {
+		case extra := <-c.outgoing:
+			payload = append(payload, extra...)
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(settle)
+		case <-timer.C:
+			return payload
+		case <-c.closeCh:
+			return payload
+		}
+	}
+}
+
+type dummyAddr string
+
+func (d dummyAddr) Network() string {
+	return "credssp"
+}
+
+func (d dummyAddr) String() string {
+	return string(d)
+}
+
+// ClientCredSSP provides a transport via CredSSP.
+type ClientCredSSP struct {
+	clientRequest
+
+	// MinimumVersion, when set, requires the server to negotiate at least this
+	// CredSSP version. CredSSP versions 2-4 use the pre-CVE-2018-0886 public-key
+	// binding, so a server claiming an old version silently downgrades the
+	// binding scheme. Set MinimumVersion to 5 to refuse that downgrade. Zero
+	// means only the protocol floor (version 2) is enforced.
+	MinimumVersion int
+
+	httpClient *http.Client
+	endpoint   *Endpoint
+	memConn    *credSSPMemoryConn
+	tlsConn    *tls.Conn
+	encryption *Encryption
+
+	handshakeComplete bool
+	// mu serializes all Post calls. CredSSP authentication state and the TLS
+	// tunnel are bound to a single connection and are not safe for concurrent
+	// use, so requests must run one at a time. A consequence is that a
+	// long-polling Receive holds the lock until it returns, so concurrent
+	// stdin sends are stalled behind it; real-time interactive stdin is
+	// therefore not supported over CredSSP.
+	mu sync.Mutex
+}
+
+// NewClientCredSSPWithDial creates a CredSSP client with custom dialer.
+func NewClientCredSSPWithDial(dial func(network, addr string) (net.Conn, error)) *ClientCredSSP {
+	return &ClientCredSSP{
+		clientRequest: clientRequest{
+			dial: dial,
+		},
+	}
+}
+
+// NewClientCredSSPWithProxyFunc creates a CredSSP client with custom proxy.
+func NewClientCredSSPWithProxyFunc(proxyfunc func(req *http.Request) (*url.URL, error)) *ClientCredSSP {
+	return &ClientCredSSP{
+		clientRequest: clientRequest{
+			proxyfunc: proxyfunc,
+		},
+	}
+}
+
+// NewClientCredSSP creates a CredSSP client.
+func NewClientCredSSP() *ClientCredSSP {
+	return &ClientCredSSP{}
+}
+
+// Transport creates the wrapped CredSSP transport.
+func (c *ClientCredSSP) Transport(endpoint *Endpoint) error {
+	if err := c.clientRequest.Transport(endpoint); err != nil {
+		return err
+	}
+	c.endpoint = endpoint
+
+	// Server-side CredSSP auth state lives on the specific TCP connection that
+	// completed the handshake, so every subsequent encrypted request must reuse
+	// that same connection. Pin the transport to a single, long-lived keep-alive
+	// connection so http.Transport cannot silently open a fresh (unauthenticated)
+	// socket for a later request.
+	if transport, ok := c.clientRequest.transport.(*http.Transport); ok {
+		transport.DisableKeepAlives = false
+		transport.MaxConnsPerHost = 1
+		transport.MaxIdleConns = 1
+		transport.MaxIdleConnsPerHost = 1
+		transport.IdleConnTimeout = 0
+	}
+
+	c.httpClient = &http.Client{Transport: c.clientRequest.transport}
+	return nil
+}
+
+// Post makes post to the winrm soap service over CredSSP.
+func (c *ClientCredSSP) Post(client *Client, request *soap.SoapMessage) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	body, err := c.post(client, request)
+	if err != nil && errors.Is(err, errCredSSPReauthRequired) {
+		// The server likely closed the idle keep-alive connection, so the
+		// transport dialed a fresh, unauthenticated socket and rejected the
+		// request. Reset CredSSP state and re-run the handshake once. A 401 is
+		// safe to retry because the server never processed the request.
+		c.resetHandshakeState()
+		body, err = c.post(client, request)
+	}
+	return body, err
+}
+
+func (c *ClientCredSSP) post(client *Client, request *soap.SoapMessage) (string, error) {
+	if err := c.ensureHandshake(client); err != nil {
+		return "", err
+	}
+
+	if c.encryption == nil {
+		encryption, err := NewEncryption("credssp")
+		if err != nil {
+			return "", err
+		}
+		encryption.httpClient = c.httpClient
+		encryption.tlsConn = c.tlsConn
+		encryption.credsspConn = c.memConn
+		encryption.timeout = credSSPTimeout(c.endpoint.Timeout)
+		c.encryption = encryption
+	}
+
+	return c.encryption.PrepareEncryptedRequest(client, client.url, []byte(request.String()))
+}
+
+func (c *ClientCredSSP) resetHandshakeState() {
+	if c.memConn != nil {
+		_ = c.memConn.Close()
+	}
+	c.handshakeComplete = false
+	c.memConn = nil
+	c.tlsConn = nil
+	c.encryption = nil
+}
+
+func (c *ClientCredSSP) ensureHandshake(client *Client) error {
+	if c.handshakeComplete {
+		return nil
+	}
+
+	cfg, err := c.tlsConfig()
+	if err != nil {
+		return err
+	}
+
+	memConn := newCredSSPMemoryConn()
+	tlsConn := tls.Client(memConn, cfg)
+
+	handshakeErr := make(chan error, 1)
+	go func() {
+		handshakeErr <- tlsConn.Handshake()
+	}()
+
+	for {
+		select {
+		case err := <-handshakeErr:
+			if err != nil {
+				_ = memConn.Close()
+				return fmt.Errorf("credssp tls handshake failed: %w", err)
+			}
+
+			c.memConn = memConn
+			c.tlsConn = tlsConn
+			if err := c.performCredSSPAuth(client); err != nil {
+				_ = memConn.Close()
+				return err
+			}
+			c.handshakeComplete = true
+			return nil
+		case out := <-memConn.outgoing:
+			// Coalesce the whole TLS flight (crypto/tls may emit several writes
+			// per flight from the handshake goroutine) into a single CredSSP
+			// token exchange, waiting a short settle window so a partial flight
+			// is never POSTed on its own.
+			token, err := c.exchangeCredSSPToken(client.url, memConn.drainOutgoingWithin(out, credSSPHandshakeDrainSettle), true)
+			if err != nil {
+				_ = memConn.Close()
+				return fmt.Errorf("credssp tls handshake token exchange: %w", err)
+			}
+			if len(token) > 0 {
+				if err := memConn.pushIncoming(token); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func (c *ClientCredSSP) tlsConfig() (*tls.Config, error) {
+	cfg := &tls.Config{
+		//nolint:gosec
+		InsecureSkipVerify: c.endpoint.Insecure,
+		ServerName:         c.endpoint.TLSServerName,
+		// Pin TLS 1.2: the header-pump assumes strict request/response
+		// lockstep, and TLS 1.3 completes the client handshake without a
+		// final round-trip, which can leave the client Finished record
+		// queued when Handshake() returns and desync app data.
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS12,
+	}
+
+	if len(c.endpoint.CACert) > 0 {
+		certPool, err := readCACerts(c.endpoint.CACert)
+		if err != nil {
+			return nil, err
+		}
+		cfg.RootCAs = certPool
+	} else if !c.endpoint.Insecure {
+		// Without a CA there is nothing to verify against; self-signed certs are
+		// normal for CredSSP, so skip verification.
+		cfg.InsecureSkipVerify = true
+	}
+
+	// crypto/tls requires a ServerName (or InsecureSkipVerify) to verify a
+	// certificate; default it to the endpoint host so a CA-only config works.
+	if !cfg.InsecureSkipVerify && cfg.ServerName == "" {
+		cfg.ServerName = c.endpoint.Host
+	}
+
+	return cfg, nil
+}
+
+func (c *ClientCredSSP) performCredSSPAuth(client *Client) error {
+	user, domain := splitUsername(client.username)
+	ntlmClient, err := ntlmssp.NewClient(
+		ntlmssp.SetUserInfo(user, client.password),
+		ntlmssp.SetDomain(domain),
+		ntlmssp.SetVersion(ntlmssp.DefaultVersion()),
+	)
+	if err != nil {
+		return err
+	}
+
+	negoToken, err := ntlmClient.Authenticate(nil, nil)
+	if err != nil {
+		return err
+	}
+	challengeRequest := tsRequest{
+		Version:    credSSPDefaultVersion,
+		NegoTokens: []negoDataItem{{NegoToken: negoToken}},
+	}
+
+	challengeResponse, err := c.sendTSRequest(client.url, challengeRequest)
+	if err != nil {
+		return fmt.Errorf("credssp negotiate/challenge exchange: %w", err)
+	}
+	if err := credSSPResponseError(challengeResponse); err != nil {
+		return err
+	}
+	if challengeResponse == nil || len(challengeResponse.NegoTokens) == 0 {
+		return errors.New("credssp challenge response missing NTLM challenge")
+	}
+
+	version, err := negotiateCredSSPVersion(credSSPDefaultVersion, challengeResponse.Version, c.MinimumVersion)
+	if err != nil {
+		return err
+	}
+
+	authToken, err := ntlmClient.Authenticate(challengeResponse.NegoTokens[0].NegoToken, nil)
+	if err != nil {
+		return err
+	}
+
+	securitySession := ntlmClient.SecuritySession()
+	if securitySession == nil {
+		return errors.New("credssp ntlm security session not established")
+	}
+
+	if len(c.tlsConn.ConnectionState().PeerCertificates) == 0 {
+		return errors.New("credssp tls peer certificate missing")
+	}
+	serverPublicKey, err := credSSPCertificatePublicKey(c.tlsConn.ConnectionState().PeerCertificates[0])
+	if err != nil {
+		return err
+	}
+
+	nonce := []byte(nil)
+	if version >= credSSPVersion5 {
+		nonce = make([]byte, 32)
+		if _, err := rand.Read(nonce); err != nil {
+			return err
+		}
+	}
+
+	clientPubKeyAuth, expectedServerPubKeyAuth, err := buildPubKeyAuthData(securitySession, serverPublicKey, version, nonce)
+	if err != nil {
+		return err
+	}
+
+	// Send the final NTLM AUTHENTICATE token together with pubKeyAuth in a
+	// single TSRequest, as in the canonical MS-CSSP exchange. The server
+	// replies with its own pubKeyAuth for verification.
+	pubKeyResponse, err := c.sendTSRequest(client.url, tsRequest{
+		Version:     version,
+		NegoTokens:  []negoDataItem{{NegoToken: authToken}},
+		PubKeyAuth:  clientPubKeyAuth,
+		ClientNonce: nonce,
+	})
+	if err != nil {
+		return fmt.Errorf("credssp authenticate/pubKeyAuth exchange: %w", err)
+	}
+	if err := credSSPResponseError(pubKeyResponse); err != nil {
+		return err
+	}
+	if pubKeyResponse == nil || len(pubKeyResponse.PubKeyAuth) == 0 {
+		return errors.New("credssp pubKeyAuth response missing")
+	}
+
+	serverPubKeyAuth, err := unwrapCredSSPData(securitySession, pubKeyResponse.PubKeyAuth)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(serverPubKeyAuth, expectedServerPubKeyAuth) {
+		return errors.New("credssp pubKeyAuth verification failed")
+	}
+
+	credentials, err := marshalCredentials(domain, user, client.password)
+	if err != nil {
+		return err
+	}
+	wrappedCredentials, err := wrapCredSSPData(securitySession, credentials)
+	if err != nil {
+		return err
+	}
+
+	// authInfo is the last client message; a compliant server sends no
+	// further TSRequest, so this exchange must be send-only. ClientNonce
+	// belongs only with pubKeyAuth, so it is omitted here.
+	if err := c.sendTSRequestNoReply(client.url, tsRequest{
+		Version:  version,
+		AuthInfo: wrappedCredentials,
+	}); err != nil {
+		return fmt.Errorf("credssp authInfo exchange: %w", err)
+	}
+
+	return nil
+}
+
+// negotiateCredSSPVersion clamps the client's version to what the server
+// reports, rejecting servers below the protocol floor and below any caller-
+// required minimum. requiredMinimum of 0 means only the protocol floor applies.
+func negotiateCredSSPVersion(clientVersion, serverVersion, requiredMinimum int) (int, error) {
+	if serverVersion < credSSPMinimumVersion {
+		return 0, fmt.Errorf("credssp server reported unsupported version %d", serverVersion)
+	}
+
+	negotiated := clientVersion
+	if serverVersion < negotiated {
+		negotiated = serverVersion
+	}
+
+	minimum := requiredMinimum
+	if minimum < credSSPMinimumVersion {
+		minimum = credSSPMinimumVersion
+	}
+	if negotiated < minimum {
+		return 0, fmt.Errorf("credssp negotiated version %d is below required minimum %d", negotiated, minimum)
+	}
+
+	return negotiated, nil
+}
+
+// credSSPResponseError returns an error if a server TSRequest carries a
+// non-zero NTSTATUS error code, so authentication failures (bad credentials,
+// policy denial, etc.) surface directly instead of as a vague downstream error.
+func credSSPResponseError(response *tsRequest) error {
+	if response != nil && response.ErrorCode != 0 {
+		return fmt.Errorf("credssp server returned error code 0x%08X", uint32(response.ErrorCode))
+	}
+	return nil
+}
+
+// credSSPCertificatePublicKey returns the certificate's public key in the exact
+// form CredSSP binds against: the PKCS#1 RSAPublicKey DER (SEQUENCE of modulus
+// and exponent), NOT the full SubjectPublicKeyInfo. Windows and the reference
+// implementations hash this PKCS#1 encoding, so using SubjectPublicKeyInfo makes
+// pubKeyAuth verification fail on the server.
+func credSSPCertificatePublicKey(cert *x509.Certificate) ([]byte, error) {
+	rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("credssp requires an RSA server certificate, got %T", cert.PublicKey)
+	}
+	return x509.MarshalPKCS1PublicKey(rsaPub), nil
+}
+
+// computePubKeyAuthPlaintext returns the plaintext the client must wrap for
+// pubKeyAuth and the plaintext it expects the server to return, per the
+// negotiated CredSSP version.
+//
+// For v2-v4 the client sends the server's public key unmodified and the server
+// returns it with its first byte incremented. For v5+ each side sends a SHA-256
+// binding hash over a directional label, the client nonce, and the public key.
+func computePubKeyAuthPlaintext(version int, nonce, serverPublicKey []byte) (clientPlaintext, expectedServer []byte) {
+	if version >= credSSPVersion5 {
+		clientPlaintext = credSSPBindingHash(credSSPClientBindingLabel, nonce, serverPublicKey)
+		expectedServer = credSSPBindingHash(credSSPServerBindingLabel, nonce, serverPublicKey)
+		return clientPlaintext, expectedServer
+	}
+
+	clientPlaintext = append([]byte(nil), serverPublicKey...)
+	expectedServer = append([]byte(nil), serverPublicKey...)
+	expectedServer[0]++
+	return clientPlaintext, expectedServer
+}
+
+func buildPubKeyAuthData(session *ntlmssp.SecuritySession, serverPublicKey []byte, version int, nonce []byte) ([]byte, []byte, error) {
+	clientPlaintext, expectedServer := computePubKeyAuthPlaintext(version, nonce, serverPublicKey)
+	wrapped, err := wrapCredSSPData(session, clientPlaintext)
+	if err != nil {
+		return nil, nil, err
+	}
+	return wrapped, expectedServer, nil
+}
+
+func credSSPBindingHash(prefix string, nonce, publicKey []byte) []byte {
+	hash := sha256.Sum256(bytes.Join([][]byte{
+		[]byte(prefix),
+		nonce,
+		publicKey,
+	}, nil))
+	return hash[:]
+}
+
+// credSSPSecurityContext is the subset of *ntlmssp.SecuritySession used to seal
+// and unseal CredSSP payloads. It exists so the wire framing can be tested with
+// a fake peer without a full NTLM handshake.
+type credSSPSecurityContext interface {
+	Wrap(b []byte) ([]byte, []byte, error)
+	Unwrap(b, signature []byte) ([]byte, error)
+}
+
+// wrapCredSSPData produces the raw SSPI output MS-CSSP expects in the
+// pubKeyAuth and authInfo fields: the NTLM message signature (a fixed 16 bytes)
+// immediately followed by the sealed data, with no length prefix.
+func wrapCredSSPData(session credSSPSecurityContext, payload []byte) ([]byte, error) {
+	sealed, signature, err := session.Wrap(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, 0, len(signature)+len(sealed))
+	data = append(data, signature...)
+	data = append(data, sealed...)
+	return data, nil
+}
+
+func unwrapCredSSPData(session credSSPSecurityContext, payload []byte) ([]byte, error) {
+	if len(payload) < ntlmSignatureLength {
+		return nil, errors.New("invalid credssp payload")
+	}
+
+	signature := payload[:ntlmSignatureLength]
+	sealed := payload[ntlmSignatureLength:]
+	return session.Unwrap(sealed, signature)
+}
+
+// writeTSRequest marshals the request, pushes it through the TLS tunnel and
+// returns the resulting TLS records (a full drained flight) to POST.
+func (c *ClientCredSSP) writeTSRequest(request tsRequest) ([]byte, error) {
+	payload, err := marshalTSRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := c.tlsConn.Write(payload); err != nil {
+		return nil, err
+	}
+
+	outgoing, err := c.memConn.popOutgoing(credSSPTimeout(c.endpoint.Timeout))
+	if err != nil {
+		return nil, err
+	}
+	return c.memConn.drainOutgoing(outgoing), nil
+}
+
+// sendTSRequest sends a TSRequest and reads the server's TSRequest reply.
+func (c *ClientCredSSP) sendTSRequest(endpoint string, request tsRequest) (*tsRequest, error) {
+	tlsRecords, err := c.writeTSRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	responseToken, err := c.exchangeCredSSPToken(endpoint, tlsRecords, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(responseToken) > 0 {
+		if err := c.memConn.pushIncoming(responseToken); err != nil {
+			return nil, err
+		}
+	}
+
+	return readTSRequest(c.tlsConn, credSSPTimeout(c.endpoint.Timeout))
+}
+
+// sendTSRequestNoReply sends a final TSRequest (e.g. authInfo) for which the
+// server returns no further TSRequest, so it never blocks on a reply.
+func (c *ClientCredSSP) sendTSRequestNoReply(endpoint string, request tsRequest) error {
+	tlsRecords, err := c.writeTSRequest(request)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.exchangeCredSSPToken(endpoint, tlsRecords, false)
+	return err
+}
+
+func readTSRequest(conn net.Conn, timeout time.Duration) (*tsRequest, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
+	defer conn.SetReadDeadline(time.Time{})
+
+	buffer := make([]byte, 0, 8192)
+	chunk := make([]byte, 4096)
+	for {
+		n, err := conn.Read(chunk)
+		if n > 0 {
+			buffer = append(buffer, chunk[:n]...)
+			// Use the outer DER SEQUENCE header to decide when a whole TSRequest
+			// has arrived, rather than matching stdlib error strings.
+			complete, total, derErr := derSequenceComplete(buffer)
+			if derErr != nil {
+				return nil, derErr
+			}
+			if complete {
+				return unmarshalTSRequest(buffer[:total])
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+	}
+}
+
+// derSequenceComplete reports whether buf contains a complete DER SEQUENCE by
+// parsing its length header, returning the total length (header + content) of
+// that SEQUENCE. It returns (false, 0, nil) when more bytes are still needed.
+func derSequenceComplete(buf []byte) (bool, int, error) {
+	if len(buf) < 2 {
+		return false, 0, nil
+	}
+	if buf[0] != 0x30 {
+		return false, 0, fmt.Errorf("unexpected ASN.1 tag 0x%02X, want SEQUENCE", buf[0])
+	}
+
+	first := buf[1]
+	if first < 0x80 {
+		total := 2 + int(first)
+		return len(buf) >= total, total, nil
+	}
+
+	numBytes := int(first & 0x7f)
+	if numBytes == 0 || numBytes > 4 {
+		return false, 0, fmt.Errorf("invalid ASN.1 length encoding")
+	}
+	if len(buf) < 2+numBytes {
+		return false, 0, nil
+	}
+
+	contentLen := 0
+	for i := 0; i < numBytes; i++ {
+		contentLen = (contentLen << 8) | int(buf[2+i])
+	}
+	total := 2 + numBytes + contentLen
+	return len(buf) >= total, total, nil
+}
+
+func (c *ClientCredSSP) exchangeCredSSPToken(endpoint string, token []byte, requireToken bool) ([]byte, error) {
+	req, err := http.NewRequest("POST", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "WinRM client")
+	req.Header.Set("Content-Length", "0")
+	req.Header.Set("Content-Type", "application/soap+xml;charset=UTF-8")
+	req.Header.Set("Connection", "Keep-Alive")
+	req.Header.Set("Authorization", fmt.Sprintf("%s %s", credSSPHeaderName, base64.StdEncoding.EncodeToString(token)))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return nil, err
+	}
+
+	responseToken, found, err := findCredSSPToken(resp.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		// Surface a real HTTP failure (e.g. 500) rather than masking it as a
+		// missing-token error. A token can legitimately accompany a 401 during
+		// negotiation, so only treat a tokenless error status as a failure.
+		if resp.StatusCode >= http.StatusBadRequest {
+			return nil, fmt.Errorf("credssp exchange failed: HTTP %d", resp.StatusCode)
+		}
+		if requireToken {
+			return nil, fmt.Errorf("credssp server did not return %s token", credSSPHeaderName)
+		}
+		return nil, nil
+	}
+	return responseToken, nil
+}
+
+func findCredSSPToken(headers http.Header) ([]byte, bool, error) {
+	for _, value := range headers.Values("WWW-Authenticate") {
+		if value == credSSPHeaderName {
+			return nil, true, nil
+		}
+		prefix := credSSPHeaderName + " "
+		if strings.HasPrefix(value, prefix) {
+			payload := strings.TrimSpace(strings.TrimPrefix(value, prefix))
+			token, err := base64.StdEncoding.DecodeString(payload)
+			return token, true, err
+		}
+	}
+	return nil, false, nil
+}

--- a/credssp_asn1.go
+++ b/credssp_asn1.go
@@ -1,0 +1,85 @@
+package winrm
+
+import (
+	"encoding/asn1"
+	"encoding/binary"
+	"errors"
+	"unicode/utf16"
+)
+
+const (
+	credSSPMinimumVersion = 2
+	credSSPVersion5       = 5
+	credSSPDefaultVersion = 6
+)
+
+const (
+	credSSPAuthTypePassword = 1
+)
+
+type negoDataItem struct {
+	NegoToken []byte `asn1:"explicit,tag:0"`
+}
+
+type tsRequest struct {
+	Version     int            `asn1:"explicit,tag:0"`
+	NegoTokens  []negoDataItem `asn1:"explicit,optional,tag:1"`
+	AuthInfo    []byte         `asn1:"explicit,optional,tag:2"`
+	PubKeyAuth  []byte         `asn1:"explicit,optional,tag:3"`
+	ErrorCode   int64          `asn1:"explicit,optional,tag:4"`
+	ClientNonce []byte         `asn1:"explicit,optional,tag:5"`
+}
+
+type tsCredentials struct {
+	CredType    int    `asn1:"explicit,tag:0"`
+	Credentials []byte `asn1:"explicit,tag:1"`
+}
+
+type tspasswordCreds struct {
+	DomainName []byte `asn1:"explicit,tag:0"`
+	UserName   []byte `asn1:"explicit,tag:1"`
+	Password   []byte `asn1:"explicit,tag:2"`
+}
+
+func marshalTSRequest(request tsRequest) ([]byte, error) {
+	return asn1.Marshal(request)
+}
+
+func unmarshalTSRequest(value []byte) (*tsRequest, error) {
+	var request tsRequest
+	rest, err := asn1.Unmarshal(value, &request)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("unexpected trailing bytes in TSRequest")
+	}
+	return &request, nil
+}
+
+// utf16LEBytes encodes a string as little-endian UTF-16, the encoding Windows
+// requires for the OCTET STRING fields of TSPasswordCreds.
+func utf16LEBytes(s string) []byte {
+	codes := utf16.Encode([]rune(s))
+	out := make([]byte, len(codes)*2)
+	for i, c := range codes {
+		binary.LittleEndian.PutUint16(out[i*2:], c)
+	}
+	return out
+}
+
+func marshalCredentials(domain, user, password string) ([]byte, error) {
+	passwordCreds, err := asn1.Marshal(tspasswordCreds{
+		DomainName: utf16LEBytes(domain),
+		UserName:   utf16LEBytes(user),
+		Password:   utf16LEBytes(password),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return asn1.Marshal(tsCredentials{
+		CredType:    credSSPAuthTypePassword,
+		Credentials: passwordCreds,
+	})
+}

--- a/credssp_integration_test.go
+++ b/credssp_integration_test.go
@@ -1,0 +1,70 @@
+//go:build credssp_integration
+
+package winrm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestCredSSPIntegration(t *testing.T) {
+	host := os.Getenv("WINRM_CREDSSP_HOST")
+	user := os.Getenv("WINRM_CREDSSP_USER")
+	password := os.Getenv("WINRM_CREDSSP_PASSWORD")
+	if host == "" || user == "" || password == "" {
+		t.Skip("set WINRM_CREDSSP_HOST, WINRM_CREDSSP_USER, and WINRM_CREDSSP_PASSWORD to run CredSSP integration tests")
+	}
+
+	port := 5985
+	if value := os.Getenv("WINRM_CREDSSP_PORT"); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("invalid WINRM_CREDSSP_PORT: %v", err)
+		}
+		port = parsed
+	}
+
+	useHTTPS := false
+	if value := os.Getenv("WINRM_CREDSSP_HTTPS"); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			t.Fatalf("invalid WINRM_CREDSSP_HTTPS: %v", err)
+		}
+		useHTTPS = parsed
+	}
+
+	insecure := true
+	if value := os.Getenv("WINRM_CREDSSP_INSECURE"); value != "" {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			t.Fatalf("invalid WINRM_CREDSSP_INSECURE: %v", err)
+		}
+		insecure = parsed
+	}
+
+	endpoint := NewEndpoint(host, port, useHTTPS, insecure, nil, nil, nil, 60*time.Second)
+	params := DefaultParameters
+	params.TransportDecorator = func() Transporter { return &ClientCredSSP{} }
+
+	client, err := NewClientWithParameters(endpoint, user, password, params)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	stdout, stderr, code, err := client.RunCmdWithContext(context.Background(), `powershell -NoProfile -Command "$env:COMPUTERNAME"`)
+	if err != nil {
+		t.Fatalf("execute remote command: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("unexpected exit code: %d, stderr=%q", code, stderr)
+	}
+	if stdout == "" {
+		t.Fatalf("expected non-empty stdout, stderr=%q", stderr)
+	}
+
+	t.Logf("CredSSP command succeeded: %s", fmt.Sprintf("%q", stdout))
+}

--- a/credssp_test.go
+++ b/credssp_test.go
@@ -1,0 +1,731 @@
+package winrm
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/binary"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *WinRMSuite) TestCredSSPTSRequestRoundTrip(c *C) {
+	original := tsRequest{
+		Version:     credSSPDefaultVersion,
+		NegoTokens:  []negoDataItem{{NegoToken: []byte("nego-1")}, {NegoToken: []byte("nego-2")}},
+		AuthInfo:    []byte("auth-info"),
+		PubKeyAuth:  []byte("pub-key"),
+		ClientNonce: []byte("nonce"),
+	}
+
+	encoded, err := marshalTSRequest(original)
+	c.Assert(err, IsNil)
+
+	decoded, err := unmarshalTSRequest(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(decoded.Version, Equals, original.Version)
+	c.Assert(decoded.NegoTokens, DeepEquals, original.NegoTokens)
+	c.Assert(decoded.AuthInfo, DeepEquals, original.AuthInfo)
+	c.Assert(decoded.PubKeyAuth, DeepEquals, original.PubKeyAuth)
+	c.Assert(decoded.ClientNonce, DeepEquals, original.ClientNonce)
+}
+
+func (s *WinRMSuite) TestCredSSPCredentialsRoundTrip(c *C) {
+	encoded, err := marshalCredentials("DOMAIN", "administrator", "s3cr3t")
+	c.Assert(err, IsNil)
+
+	var creds tsCredentials
+	rest, err := asn1.Unmarshal(encoded, &creds)
+	c.Assert(err, IsNil)
+	c.Assert(len(rest), Equals, 0)
+	c.Assert(creds.CredType, Equals, credSSPAuthTypePassword)
+
+	var passwordCreds tspasswordCreds
+	rest, err = asn1.Unmarshal(creds.Credentials, &passwordCreds)
+	c.Assert(err, IsNil)
+	c.Assert(len(rest), Equals, 0)
+	// Credentials must be UTF-16LE encoded for Windows.
+	c.Assert(passwordCreds.DomainName, DeepEquals, utf16LEBytes("DOMAIN"))
+	c.Assert(passwordCreds.UserName, DeepEquals, utf16LEBytes("administrator"))
+	c.Assert(passwordCreds.Password, DeepEquals, utf16LEBytes("s3cr3t"))
+	// Sanity check the encoding: ASCII chars become byte + 0x00.
+	c.Assert(passwordCreds.DomainName[:4], DeepEquals, []byte{'D', 0x00, 'O', 0x00})
+}
+
+func (s *WinRMSuite) TestCredSSPTrailerLengthTable(c *C) {
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+
+	testCases := []struct {
+		name       string
+		messageLen int
+		cipher     string
+		expected   int
+	}{
+		{name: "gcm", messageLen: 31, cipher: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", expected: 16},
+		{name: "rc4", messageLen: 31, cipher: "TLS_RSA_WITH_RC4_128_SHA", expected: 20},
+		{name: "3des", messageLen: 31, cipher: "TLS_RSA_WITH_3DES_EDE_CBC_SHA", expected: 25},
+		{name: "aes-cbc-sha256", messageLen: 31, cipher: "TLS_RSA_WITH_AES_128_CBC_SHA256", expected: 33},
+		{name: "aes-cbc-sha384", messageLen: 31, cipher: "TLS_RSA_WITH_AES_256_CBC_SHA384", expected: 49},
+	}
+
+	for _, tc := range testCases {
+		c.Assert(encryption.getCredSSPTrailerLength(tc.messageLen, tc.cipher), Equals, tc.expected, Commentf(tc.name))
+	}
+}
+
+func (s *WinRMSuite) TestCredSSPBuildDecryptRoundTrip(c *C) {
+	clientConn, serverConn, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+	encryption.tlsConn = clientConn.tlsConn
+	encryption.credsspConn = clientConn.memConn
+	encryption.timeout = 5 * time.Second
+
+	request := []byte("create shell request")
+	wrappedRequest, err := encryption.buildCredSSPMessage(request, "host")
+	c.Assert(err, IsNil)
+	c.Assert(len(wrappedRequest) > 4, Equals, true)
+
+	if err := serverConn.memConn.pushIncoming(wrappedRequest[4:]); err != nil {
+		c.Fatal(err)
+	}
+	receivedRequest := make([]byte, len(request))
+	n, err := serverConn.tlsConn.Read(receivedRequest)
+	c.Assert(err, IsNil)
+	c.Assert(receivedRequest[:n], DeepEquals, request)
+
+	response := []byte("create shell response")
+	_, err = serverConn.tlsConn.Write(response)
+	c.Assert(err, IsNil)
+	serverCiphertext, err := serverConn.memConn.popOutgoing(5 * time.Second)
+	c.Assert(err, IsNil)
+	serverCiphertext = serverConn.memConn.drainOutgoing(serverCiphertext)
+
+	cipherName := tls.CipherSuiteName(clientConn.tlsConn.ConnectionState().CipherSuite)
+	trailer := encryption.getCredSSPTrailerLength(len(response), cipherName)
+	payload := make([]byte, 4+len(serverCiphertext))
+	binary.LittleEndian.PutUint32(payload[:4], uint32(trailer))
+	copy(payload[4:], serverCiphertext)
+
+	decrypted, err := encryption.decryptCredsspMessage(payload, "host", len(response))
+	c.Assert(err, IsNil)
+	c.Assert(decrypted, DeepEquals, response)
+}
+
+// fakeSecurityContext is a reversible stand-in for *ntlmssp.SecuritySession so
+// the CredSSP wire framing can be asserted without a full NTLM handshake.
+type fakeSecurityContext struct {
+	signature []byte
+}
+
+func (f *fakeSecurityContext) Wrap(b []byte) ([]byte, []byte, error) {
+	sealed := make([]byte, len(b))
+	for i := range b {
+		sealed[i] = b[i] ^ 0xAA
+	}
+	return sealed, append([]byte(nil), f.signature...), nil
+}
+
+func (f *fakeSecurityContext) Unwrap(b, signature []byte) ([]byte, error) {
+	if !bytes.Equal(signature, f.signature) {
+		return nil, errors.New("signature mismatch")
+	}
+	out := make([]byte, len(b))
+	for i := range b {
+		out[i] = b[i] ^ 0xAA
+	}
+	return out, nil
+}
+
+// TestCredSSPWrapWireFormat guards the MS-CSSP framing: signature (16 bytes)
+// immediately followed by sealed data, with no 4-byte length prefix.
+func (s *WinRMSuite) TestCredSSPWrapWireFormat(c *C) {
+	signature := bytes.Repeat([]byte{0x11}, ntlmSignatureLength)
+	ctx := &fakeSecurityContext{signature: signature}
+	payload := []byte("public-key-info-payload")
+
+	wrapped, err := wrapCredSSPData(ctx, payload)
+	c.Assert(err, IsNil)
+
+	// No length prefix: exactly signature + sealed, and RC4-style sealing keeps
+	// the sealed length equal to the plaintext length.
+	c.Assert(len(wrapped), Equals, ntlmSignatureLength+len(payload))
+	c.Assert(wrapped[:ntlmSignatureLength], DeepEquals, signature)
+
+	expectedSealed := make([]byte, len(payload))
+	for i := range payload {
+		expectedSealed[i] = payload[i] ^ 0xAA
+	}
+	c.Assert(wrapped[ntlmSignatureLength:], DeepEquals, expectedSealed)
+
+	// The signature must be at the very front; a stray length prefix would put
+	// the first signature byte at offset 4 instead of 0.
+	c.Assert(wrapped[0], Equals, byte(0x11))
+
+	out, err := unwrapCredSSPData(ctx, wrapped)
+	c.Assert(err, IsNil)
+	c.Assert(out, DeepEquals, payload)
+}
+
+func (s *WinRMSuite) TestCredSSPUnwrapRejectsShortPayload(c *C) {
+	ctx := &fakeSecurityContext{signature: bytes.Repeat([]byte{0x11}, ntlmSignatureLength)}
+	_, err := unwrapCredSSPData(ctx, []byte{0x00, 0x01, 0x02})
+	c.Assert(err, NotNil)
+}
+
+// TestCredSSPPubKeyAuthDirection guards the v2-v4 vs v5+ pubKeyAuth direction:
+// pre-v5 the client sends the key unmodified and expects it back +1; v5+ uses
+// distinct directional SHA-256 binding hashes.
+func (s *WinRMSuite) TestCredSSPPubKeyAuthDirection(c *C) {
+	pubKey := []byte{0x30, 0x82, 0x01, 0x0a, 0x02, 0x82}
+
+	clientPlain, expected := computePubKeyAuthPlaintext(4, nil, pubKey)
+	c.Assert(clientPlain, DeepEquals, pubKey)
+
+	wantExpected := append([]byte(nil), pubKey...)
+	wantExpected[0]++
+	c.Assert(expected, DeepEquals, wantExpected)
+	// The input key must not be mutated in place.
+	c.Assert(pubKey[0], Equals, byte(0x30))
+
+	nonce := bytes.Repeat([]byte{0x07}, 32)
+	clientHash, serverHash := computePubKeyAuthPlaintext(credSSPDefaultVersion, nonce, pubKey)
+	c.Assert(len(clientHash), Equals, 32)
+	c.Assert(len(serverHash), Equals, 32)
+	c.Assert(bytes.Equal(clientHash, serverHash), Equals, false)
+	c.Assert(clientHash, DeepEquals, credSSPBindingHash(credSSPClientBindingLabel, nonce, pubKey))
+	c.Assert(serverHash, DeepEquals, credSSPBindingHash(credSSPServerBindingLabel, nonce, pubKey))
+}
+
+// TestCredSSPDecryptSpansMultipleRecords guards decrypting a chunk whose
+// plaintext spans several TLS records (finding: a single Read returns short).
+func (s *WinRMSuite) TestCredSSPDecryptSpansMultipleRecords(c *C) {
+	clientConn, serverConn, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+	encryption.tlsConn = clientConn.tlsConn
+	encryption.credsspConn = clientConn.memConn
+	encryption.timeout = 5 * time.Second
+
+	// Larger than a single 16 KB TLS record to force multiple records.
+	response := bytes.Repeat([]byte("ABCDEFGH"), 5000)
+	_, err = serverConn.tlsConn.Write(response)
+	c.Assert(err, IsNil)
+
+	sealedFirst, err := serverConn.memConn.popOutgoing(5 * time.Second)
+	c.Assert(err, IsNil)
+	sealed := serverConn.memConn.drainOutgoing(sealedFirst)
+
+	cipherName := tls.CipherSuiteName(clientConn.tlsConn.ConnectionState().CipherSuite)
+	trailer := encryption.getCredSSPTrailerLength(len(response), cipherName)
+	payload := make([]byte, 4+len(sealed))
+	binary.LittleEndian.PutUint32(payload[:4], uint32(trailer))
+	copy(payload[4:], sealed)
+
+	decrypted, err := encryption.decryptCredsspMessage(payload, "host", len(response))
+	c.Assert(err, IsNil)
+	c.Assert(decrypted, DeepEquals, response)
+}
+
+// TestCredSSPDecryptTamperedFails ensures a modified ciphertext is rejected by
+// the TLS integrity layer rather than returning corrupt plaintext.
+func (s *WinRMSuite) TestCredSSPDecryptTamperedFails(c *C) {
+	clientConn, serverConn, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+	encryption.tlsConn = clientConn.tlsConn
+	encryption.credsspConn = clientConn.memConn
+	encryption.timeout = 2 * time.Second
+
+	response := []byte("sensitive data payload")
+	_, err = serverConn.tlsConn.Write(response)
+	c.Assert(err, IsNil)
+
+	sealedFirst, err := serverConn.memConn.popOutgoing(5 * time.Second)
+	c.Assert(err, IsNil)
+	sealed := serverConn.memConn.drainOutgoing(sealedFirst)
+
+	// Corrupt the final ciphertext byte; TLS AEAD verification must fail.
+	sealed[len(sealed)-1] ^= 0xFF
+
+	cipherName := tls.CipherSuiteName(clientConn.tlsConn.ConnectionState().CipherSuite)
+	trailer := encryption.getCredSSPTrailerLength(len(response), cipherName)
+	payload := make([]byte, 4+len(sealed))
+	binary.LittleEndian.PutUint32(payload[:4], uint32(trailer))
+	copy(payload[4:], sealed)
+
+	_, err = encryption.decryptCredsspMessage(payload, "host", len(response))
+	c.Assert(err, NotNil)
+}
+
+// TestCredSSPFinalMessageIsSendOnly guards finding 3: the final authInfo message
+// must not block or fail waiting for a server reply that never comes.
+func (s *WinRMSuite) TestCredSSPFinalMessageIsSendOnly(c *C) {
+	clientConn, _, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	ts, _, _, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+
+	client := &ClientCredSSP{
+		httpClient: &http.Client{},
+		endpoint:   &Endpoint{Timeout: 5 * time.Second},
+		tlsConn:    clientConn.tlsConn,
+		memConn:    clientConn.memConn,
+	}
+
+	err = client.sendTSRequestNoReply(ts.URL, tsRequest{
+		Version:  credSSPDefaultVersion,
+		AuthInfo: []byte("delegated-credentials"),
+	})
+	c.Assert(err, IsNil)
+}
+
+// TestCredSSPReplyRequiredFailsWithoutToken confirms the reply-required path
+// still errors when no CredSSP token is returned, i.e. the send-only path above
+// is genuinely necessary for the final message.
+func (s *WinRMSuite) TestCredSSPReplyRequiredFailsWithoutToken(c *C) {
+	clientConn, _, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	ts, _, _, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+
+	client := &ClientCredSSP{
+		httpClient: &http.Client{},
+		endpoint:   &Endpoint{Timeout: 5 * time.Second},
+		tlsConn:    clientConn.tlsConn,
+		memConn:    clientConn.memConn,
+	}
+
+	_, err = client.sendTSRequest(ts.URL, tsRequest{
+		Version:    credSSPDefaultVersion,
+		NegoTokens: []negoDataItem{{NegoToken: []byte("token")}},
+	})
+	c.Assert(err, NotNil)
+}
+
+// TestCredSSPResponseErrorCode guards that a server TSRequest carrying an
+// NTSTATUS error code is surfaced instead of being ignored.
+func (s *WinRMSuite) TestCredSSPResponseErrorCode(c *C) {
+	c.Assert(credSSPResponseError(nil), IsNil)
+	c.Assert(credSSPResponseError(&tsRequest{Version: credSSPDefaultVersion}), IsNil)
+
+	// Use a real NTSTATUS whose high bit is set; this must round-trip through
+	// ASN.1 (int64) on any platform, including 32-bit.
+	encoded, err := marshalTSRequest(tsRequest{Version: credSSPDefaultVersion, ErrorCode: 0xC000006A})
+	c.Assert(err, IsNil)
+	decoded, err := unmarshalTSRequest(encoded)
+	c.Assert(err, IsNil)
+
+	err = credSSPResponseError(decoded)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Contains, "0xC000006A")
+}
+
+// TestCredSSPCertificatePublicKey guards that CredSSP binds against the PKCS#1
+// RSAPublicKey encoding, not the full SubjectPublicKeyInfo (a mismatch here
+// makes real Windows servers reject pubKeyAuth).
+func (s *WinRMSuite) TestCredSSPCertificatePublicKey(c *C) {
+	certificate, err := generateCredSSPTestCertificate()
+	c.Assert(err, IsNil)
+
+	parsed, err := x509.ParseCertificate(certificate.Certificate[0])
+	c.Assert(err, IsNil)
+
+	pkcs1, err := credSSPCertificatePublicKey(parsed)
+	c.Assert(err, IsNil)
+
+	rsaPub, ok := parsed.PublicKey.(*rsa.PublicKey)
+	c.Assert(ok, Equals, true)
+	c.Assert(pkcs1, DeepEquals, x509.MarshalPKCS1PublicKey(rsaPub))
+
+	// It must NOT be the SubjectPublicKeyInfo (the previous, incorrect form).
+	c.Assert(bytes.Equal(pkcs1, parsed.RawSubjectPublicKeyInfo), Equals, false)
+	c.Assert(len(pkcs1) < len(parsed.RawSubjectPublicKeyInfo), Equals, true)
+}
+
+// TestNegotiateCredSSPVersion guards the version floor and the CVE-2018-0886
+// minimum-version knob.
+func (s *WinRMSuite) TestNegotiateCredSSPVersion(c *C) {
+	v, err := negotiateCredSSPVersion(6, 8, 0)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, 6)
+
+	v, err = negotiateCredSSPVersion(6, 3, 0)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, 3)
+
+	_, err = negotiateCredSSPVersion(6, 1, 0)
+	c.Assert(err, NotNil)
+
+	_, err = negotiateCredSSPVersion(6, 0, 0)
+	c.Assert(err, NotNil)
+
+	// Caller requires 5+, server offers 3 -> rejected downgrade.
+	_, err = negotiateCredSSPVersion(6, 3, 5)
+	c.Assert(err, NotNil)
+
+	v, err = negotiateCredSSPVersion(6, 6, 5)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, 6)
+}
+
+// TestDERSequenceComplete guards the DER-length-based framing used to decide a
+// full TSRequest has arrived.
+func (s *WinRMSuite) TestDERSequenceComplete(c *C) {
+	encoded, err := marshalTSRequest(tsRequest{
+		Version:    credSSPDefaultVersion,
+		NegoTokens: []negoDataItem{{NegoToken: bytes.Repeat([]byte{0x41}, 300)}},
+	})
+	c.Assert(err, IsNil)
+
+	done, _, err := derSequenceComplete(encoded[:4])
+	c.Assert(err, IsNil)
+	c.Assert(done, Equals, false)
+
+	done, total, err := derSequenceComplete(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(done, Equals, true)
+	c.Assert(total, Equals, len(encoded))
+
+	// Trailing bytes beyond the SEQUENCE are not counted in its length.
+	done, total, err = derSequenceComplete(append(append([]byte(nil), encoded...), 0xFF, 0xFF))
+	c.Assert(err, IsNil)
+	c.Assert(done, Equals, true)
+	c.Assert(total, Equals, len(encoded))
+
+	_, _, err = derSequenceComplete([]byte{0x02, 0x01, 0x05})
+	c.Assert(err, NotNil)
+}
+
+// TestCredSSPTLSConfig guards the CA/ServerName handling.
+func (s *WinRMSuite) TestCredSSPTLSConfig(c *C) {
+	// Bad CA bytes surface an error instead of being swallowed.
+	badClient := &ClientCredSSP{endpoint: &Endpoint{Host: "winhost", CACert: []byte("-----BEGIN CERTIFICATE-----\nnope\n-----END CERTIFICATE-----")}}
+	_, err := badClient.tlsConfig()
+	c.Assert(err, NotNil)
+
+	// Valid CA, verifying, no explicit ServerName -> defaults to the host.
+	certificate, err := generateCredSSPTestCertificate()
+	c.Assert(err, IsNil)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Certificate[0]})
+
+	verifying := &ClientCredSSP{endpoint: &Endpoint{Host: "winhost", CACert: caPEM, Insecure: false}}
+	cfg, err := verifying.tlsConfig()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.InsecureSkipVerify, Equals, false)
+	c.Assert(cfg.ServerName, Equals, "winhost")
+	c.Assert(cfg.RootCAs, NotNil)
+
+	// No CA and not explicitly insecure -> nothing to verify, so skip.
+	noCA := &ClientCredSSP{endpoint: &Endpoint{Host: "winhost", Insecure: false}}
+	cfg, err = noCA.tlsConfig()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.InsecureSkipVerify, Equals, true)
+}
+
+// TestCredSSPReauthRequiredOn401 guards that a 401 on an encrypted request is
+// surfaced as the re-auth sentinel so Post can re-handshake.
+func (s *WinRMSuite) TestCredSSPReauthRequiredOn401(c *C) {
+	clientConn, _, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	ts, _, _, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+	encryption.httpClient = &http.Client{}
+	encryption.tlsConn = clientConn.tlsConn
+	encryption.credsspConn = clientConn.memConn
+	encryption.timeout = 5 * time.Second
+
+	_, err = encryption.PrepareEncryptedRequest(&Client{}, ts.URL, []byte("<soap/>"))
+	c.Assert(errors.Is(err, errCredSSPReauthRequired), Equals, true)
+}
+
+// TestCredSSPEncryptMessagePropagatesError ensures a tunnel failure during
+// message wrapping is returned instead of silently producing a malformed body.
+func (s *WinRMSuite) TestCredSSPEncryptMessagePropagatesError(c *C) {
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+
+	// tlsConn/credsspConn are unset, so buildCredSSPMessage fails.
+	_, err = encryption.encryptMessage([]byte("payload"), "host")
+	c.Assert(err, NotNil)
+}
+
+// TestCredSSPMemoryConnReadDeadline ensures the read deadline is honored so a
+// starved Read returns instead of blocking forever.
+func TestCredSSPMemoryConnReadDeadline(t *testing.T) {
+	conn := newCredSSPMemoryConn()
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 8)
+	_, err := conn.Read(buf)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+}
+
+// TestCredSSPDecryptTimesOutOnTruncatedResponse guards that a server response
+// shorter than the declared length times out instead of hanging (the read
+// deadline must actually take effect through the TLS tunnel).
+func (s *WinRMSuite) TestCredSSPDecryptTimesOutOnTruncatedResponse(c *C) {
+	clientConn, serverConn, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	encryption, err := NewEncryption("credssp")
+	c.Assert(err, IsNil)
+	encryption.tlsConn = clientConn.tlsConn
+	encryption.credsspConn = clientConn.memConn
+	encryption.timeout = 200 * time.Millisecond
+
+	response := []byte("short")
+	_, err = serverConn.tlsConn.Write(response)
+	c.Assert(err, IsNil)
+	sealedFirst, err := serverConn.memConn.popOutgoing(5 * time.Second)
+	c.Assert(err, IsNil)
+	sealed := serverConn.memConn.drainOutgoing(sealedFirst)
+
+	cipherName := tls.CipherSuiteName(clientConn.tlsConn.ConnectionState().CipherSuite)
+	trailer := encryption.getCredSSPTrailerLength(len(response), cipherName)
+	payload := make([]byte, 4+len(sealed))
+	binary.LittleEndian.PutUint32(payload[:4], uint32(trailer))
+	copy(payload[4:], sealed)
+
+	start := time.Now()
+	// Declare more plaintext than was actually sent.
+	_, err = encryption.decryptCredsspMessage(payload, "host", len(response)+64)
+	c.Assert(err, NotNil)
+	c.Assert(time.Since(start) < 5*time.Second, Equals, true)
+}
+
+// TestCredSSPExchangeSurfacesHTTPError guards that an error HTTP status is
+// reported instead of a vague missing-token message.
+func (s *WinRMSuite) TestCredSSPExchangeSurfacesHTTPError(c *C) {
+	clientConn, _, err := newCredSSPTLSHarness()
+	c.Assert(err, IsNil)
+
+	ts, _, _, err := StartTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	c.Assert(err, IsNil)
+	defer ts.Close()
+
+	client := &ClientCredSSP{
+		httpClient: &http.Client{},
+		endpoint:   &Endpoint{Timeout: 5 * time.Second},
+		tlsConn:    clientConn.tlsConn,
+		memConn:    clientConn.memConn,
+	}
+
+	_, err = client.sendTSRequest(ts.URL, tsRequest{
+		Version:    credSSPDefaultVersion,
+		NegoTokens: []negoDataItem{{NegoToken: []byte("token")}},
+	})
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Contains, "HTTP 500")
+}
+
+// TestCredSSPMemoryConnCloseRace guards finding 7: Close must not race with
+// concurrent pushIncoming senders (a closed incoming channel would panic).
+func TestCredSSPMemoryConnCloseRace(t *testing.T) {
+	for iteration := 0; iteration < 50; iteration++ {
+		conn := newCredSSPMemoryConn()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				if err := conn.pushIncoming([]byte("payload")); err != nil {
+					return
+				}
+			}
+		}()
+
+		conn.Close()
+		wg.Wait()
+	}
+}
+
+func (s *WinRMSuite) TestFindCredSSPToken(c *C) {
+	headers := http.Header{}
+	headers.Add("WWW-Authenticate", "Negotiate")
+	headers.Add("WWW-Authenticate", "CredSSP YWJjZA==")
+
+	token, found, err := findCredSSPToken(headers)
+	c.Assert(err, IsNil)
+	c.Assert(found, Equals, true)
+	c.Assert(string(token), Equals, "abcd")
+}
+
+func TestCredSSPMemoryConn(t *testing.T) {
+	conn := newCredSSPMemoryConn()
+	defer conn.Close()
+
+	payload := []byte("hello")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	out, err := conn.popOutgoing(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.pushIncoming(out); err != nil {
+		t.Fatal(err)
+	}
+
+	buffer := make([]byte, len(payload))
+	n, err := conn.Read(buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buffer[:n]) != "hello" {
+		t.Fatalf("unexpected payload %q", string(buffer[:n]))
+	}
+}
+
+type credSSPTLSEndpoint struct {
+	tlsConn *tls.Conn
+	memConn *credSSPMemoryConn
+}
+
+func newCredSSPTLSHarness() (*credSSPTLSEndpoint, *credSSPTLSEndpoint, error) {
+	certificate, err := generateCredSSPTestCertificate()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clientMem := newCredSSPMemoryConn()
+	serverMem := newCredSSPMemoryConn()
+
+	clientTLS := tls.Client(clientMem, &tls.Config{
+		//nolint:gosec
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+	})
+	serverTLS := tls.Server(serverMem, &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+	})
+
+	clientErr := make(chan error, 1)
+	serverErr := make(chan error, 1)
+	go func() { clientErr <- clientTLS.Handshake() }()
+	go func() { serverErr <- serverTLS.Handshake() }()
+
+	if err := pumpCredSSPHandshake(clientMem, serverMem, clientErr, serverErr); err != nil {
+		return nil, nil, err
+	}
+
+	return &credSSPTLSEndpoint{tlsConn: clientTLS, memConn: clientMem}, &credSSPTLSEndpoint{tlsConn: serverTLS, memConn: serverMem}, nil
+}
+
+func pumpCredSSPHandshake(clientMem, serverMem *credSSPMemoryConn, clientErr, serverErr <-chan error) error {
+	clientDone := false
+	serverDone := false
+	timeout := time.After(10 * time.Second)
+
+	for !clientDone || !serverDone {
+		select {
+		case err := <-clientErr:
+			if err != nil {
+				return err
+			}
+			clientDone = true
+		case err := <-serverErr:
+			if err != nil {
+				return err
+			}
+			serverDone = true
+		case outgoing := <-clientMem.outgoing:
+			if err := serverMem.pushIncoming(outgoing); err != nil {
+				return err
+			}
+		case outgoing := <-serverMem.outgoing:
+			if err := clientMem.pushIncoming(outgoing); err != nil {
+				return err
+			}
+		case <-timeout:
+			return errors.New("timed out waiting for TLS handshake")
+		}
+	}
+
+	return nil
+}
+
+func generateCredSSPTestCertificate() (tls.Certificate, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "credssp.test",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  privateKey,
+	}, nil
+}

--- a/encryption.go
+++ b/encryption.go
@@ -2,6 +2,7 @@ package winrm
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bodgit/ntlmssp"
 	ntlmhttp "github.com/bodgit/ntlmssp/http"
@@ -23,6 +25,9 @@ type Encryption struct {
 	httpClient     *http.Client
 	ntlmClient     *ntlmssp.Client
 	ntlmhttp       *ntlmhttp.Client
+	tlsConn        *tls.Conn
+	credsspConn    *credSSPMemoryConn
+	timeout        time.Duration
 }
 
 const (
@@ -63,11 +68,12 @@ func NewEncryption(protocol string) (*Encryption, error) {
 	case "ntlm":
 		encryption.protocolString = []byte("application/HTTP-SPNEGO-session-encrypted")
 		return encryption, nil
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			encryption.protocolString = []byte("application/HTTP-CredSSP-session-encrypted")
+	case "credssp":
+		encryption.protocolString = []byte("application/HTTP-CredSSP-session-encrypted")
+		return encryption, nil
+		/* kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
 		case "kerberos": // kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-			encryption.protocolString = []byte("application/HTTP-SPNEGO-session-encrypted")
+				encryption.protocolString = []byte("application/HTTP-SPNEGO-session-encrypted")
 		*/
 	}
 
@@ -80,19 +86,9 @@ func (e *Encryption) Transport(endpoint *Endpoint) error {
 }
 
 func (e *Encryption) Post(client *Client, message *soap.SoapMessage) (string, error) {
-	var userName, domain string
-	if strings.Contains(client.username, "@") {
-		parts := strings.Split(client.username, "@")
-		domain = parts[1]
-		userName = parts[0]
-	} else if strings.Contains(client.username, "\\") {
-		parts := strings.Split(client.username, "\\")
-		domain = parts[0]
-		userName = parts[1]
-	} else {
-		userName = client.username
-	}
-
+	// Note: CredSSP does not use this path. ClientCredSSP.Post drives the
+	// handshake and calls PrepareEncryptedRequest directly.
+	userName, domain := splitUsername(client.username)
 	e.ntlmClient, _ = ntlmssp.NewClient(ntlmssp.SetUserInfo(userName, client.password), ntlmssp.SetDomain(domain), ntlmssp.SetVersion(ntlmssp.DefaultVersion()))
 	e.ntlmhttp, _ = ntlmhttp.NewClient(e.httpClient, e.ntlmClient)
 
@@ -158,15 +154,25 @@ func (e *Encryption) PrepareEncryptedRequest(client *Client, endpoint string, me
 		encrypted_message = []byte{}
 		message_chunks := [][]byte{}
 		for i := 0; i < len(message); i += sixTenKB {
-			message_chunks = append(message_chunks, message[i:i+sixTenKB])
+			end := i + sixTenKB
+			if end > len(message) {
+				end = len(message)
+			}
+			message_chunks = append(message_chunks, message[i:end])
 		}
 		for _, message_chunk := range message_chunks {
-			encrypted_chunk := e.encryptMessage(message_chunk, host)
+			encrypted_chunk, err := e.encryptMessage(message_chunk, host)
+			if err != nil {
+				return "", err
+			}
 			encrypted_message = append(encrypted_message, encrypted_chunk...)
 		}
 	} else {
 		content_type = "multipart/encrypted"
-		encrypted_message = e.encryptMessage(message, host)
+		encrypted_message, err = e.encryptMessage(message, host)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	encrypted_message = append(encrypted_message, []byte(mimeBoundary)...)
@@ -182,9 +188,26 @@ func (e *Encryption) PrepareEncryptedRequest(client *Client, endpoint string, me
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(encrypted_message)))
 	req.Header.Set("Content-Type", fmt.Sprintf(`%s;protocol="%s";boundary="Encrypted Boundary"`, content_type, e.protocolString))
 
-	resp, err := e.ntlmhttp.Do(req)
+	var resp *http.Response
+	switch e.protocol {
+	case "ntlm":
+		resp, err = e.ntlmhttp.Do(req)
+	case "credssp":
+		resp, err = e.httpClient.Do(req)
+	default:
+		return "", errors.New("Encryption for protocol " + e.protocol + " not supported")
+	}
 	if err != nil {
 		return "", fmt.Errorf("unknown error %w", err)
+	}
+
+	// A 401 on an encrypted CredSSP request means the connection is no longer
+	// authenticated (typically re-dialed after the server dropped the pinned
+	// socket). Signal the transport to re-run the handshake.
+	if e.protocol == "credssp" && resp.StatusCode == http.StatusUnauthorized {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return "", errCredSSPReauthRequired
 	}
 
 	body, err := e.ParseEncryptedResponse(resp)
@@ -211,8 +234,13 @@ func (e *Encryption) ParseEncryptedResponse(response *http.Response) ([]byte, er
 	return body, nil
 }
 
-func (e *Encryption) encryptMessage(message []byte, host string) []byte {
-	encryptedStream, _ := e.buildMessage(message, host)
+func (e *Encryption) encryptMessage(message []byte, host string) ([]byte, error) {
+	// For CredSSP, buildMessage performs a real TLS write that can fail or time
+	// out, so the error must be surfaced rather than producing a malformed body.
+	encryptedStream, err := e.buildMessage(message, host)
+	if err != nil {
+		return nil, err
+	}
 
 	messagePayload := bytes.Join([][]byte{
 		[]byte(mimeBoundary),
@@ -225,7 +253,7 @@ func (e *Encryption) encryptMessage(message []byte, host string) []byte {
 		encryptedStream,
 	}, []byte{})
 
-	return messagePayload
+	return messagePayload, nil
 }
 
 func deleteEmpty(b [][]byte) [][]byte {
@@ -262,7 +290,7 @@ func (e *Encryption) decryptResponse(response *http.Response, host string) ([]by
 			payload = payload[:len(payload)-boundaryLength-4]
 		}
 		encryptedData := bytes.ReplaceAll(payload, []byte("\tContent-Type: application/octet-stream\r\n"), []byte{})
-		decryptedMessage, err := e.decryptMessage(encryptedData, host)
+		decryptedMessage, err := e.decryptMessage(encryptedData, host, expectedLength)
 		if err != nil {
 			return nil, err
 		}
@@ -278,16 +306,14 @@ func (e *Encryption) decryptResponse(response *http.Response, host string) ([]by
 	return message, nil
 }
 
-func (e *Encryption) decryptMessage(encryptedData []byte, host string) ([]byte, error) {
+func (e *Encryption) decryptMessage(encryptedData []byte, host string, expectedLength int) ([]byte, error) {
 	switch e.protocol {
 	case "ntlm":
 		return e.decryptNtlmMessage(encryptedData, host)
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			return e.decryptCredsspMessage(encryptedData, host)
-		case "kerberos":
-			return e.decryptKerberosMessage(encryptedData, host)
-		*/
+	case "credssp":
+		return e.decryptCredsspMessage(encryptedData, host, expectedLength)
+	case "kerberos":
+		return e.decryptKerberosMessage(encryptedData, host)
 	default:
 		return nil, errors.New("Encryption for protocol " + e.protocol + " not supported")
 	}
@@ -305,21 +331,33 @@ func (e *Encryption) decryptNtlmMessage(encryptedData []byte, host string) ([]by
 	return message, nil
 }
 
-/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-func (e *Encryption) decryptCredsspMessage(encryptedData []byte, host string) ([]byte, error) {
-	// // TODO
-	// encryptedMessage := encryptedData[4:]
+func (e *Encryption) decryptCredsspMessage(encryptedData []byte, host string, expectedLength int) ([]byte, error) {
+	if e.tlsConn == nil || e.credsspConn == nil {
+		return nil, errors.New("credssp tls context not initialized")
+	}
+	if len(encryptedData) < 4 {
+		return nil, errors.New("credssp encrypted payload too short")
+	}
 
-	// credsspContext, ok := e.session.Auth.Contexts()[host]
-	// if !ok {
-	// 	return nil, fmt.Errorf("credssp context not found for host: %s", host)
-	// }
+	// Skip the 4-byte CredSSP trailer length prefix and feed the wrapped TLS
+	// record(s) into the tunnel.
+	sealed := encryptedData[4:]
+	if err := e.credsspConn.pushIncoming(sealed); err != nil {
+		return nil, err
+	}
 
-	// message, err := credsspContext.Unwrap(encryptedMessage)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// return message, nil
+	_ = e.tlsConn.SetReadDeadline(time.Now().Add(credSSPTimeout(e.timeout)))
+	defer e.tlsConn.SetReadDeadline(time.Time{})
+
+	// The plaintext length is authoritatively given by the MIME OriginalContent
+	// header. A single Read returns at most one TLS record's plaintext, so read
+	// the full declared length across however many records it spans.
+	message := make([]byte, expectedLength)
+	if _, err := io.ReadFull(e.tlsConn, message); err != nil {
+		return nil, err
+	}
+
+	return message, nil
 }
 
 func (enc *Encryption) decryptKerberosMessage(encryptedData []byte, host string) ([]byte, error) {
@@ -334,19 +372,17 @@ func (enc *Encryption) decryptKerberosMessage(encryptedData []byte, host string)
 	// }
 
 	// return message, nil
+	return nil, errors.New("kerberos encryption is not implemented")
 }
-*/
 
 func (e *Encryption) buildMessage(encryptedData []byte, host string) ([]byte, error) {
 	switch e.protocol {
 	case "ntlm":
 		return e.buildNTLMMessage(encryptedData, host)
-		/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
-		case "credssp":
-			return e.buildCredSSPMessage(encryptedData, host)
-		case "kerberos":
-			return e.buildKerberosMessage(encryptedData, host)
-		*/
+	case "credssp":
+		return e.buildCredSSPMessage(encryptedData, host)
+	case "kerberos":
+		return e.buildKerberosMessage(encryptedData, host)
 	default:
 		return nil, errors.New("Encryption for protocol " + e.protocol + " not supported")
 	}
@@ -372,19 +408,27 @@ func (enc *Encryption) buildNTLMMessage(message []byte, host string) ([]byte, er
 	return buf.Bytes(), nil
 }
 
-/* credssp and kerberos is currently unimplemented, leave holder for future to keep in sync with python implementation
 func (e *Encryption) buildCredSSPMessage(message []byte, host string) ([]byte, error) {
-	// //TODO
-	// context := e.session.Auth.Contexts[host]
-	// sealedMessage := context.Wrap(message)
+	if e.tlsConn == nil || e.credsspConn == nil {
+		return nil, errors.New("credssp tls context not initialized")
+	}
 
-	// cipherNegotiated := context.TLSConnection.ConnectionState().CipherSuite.Name
-	// trailerLength := e.getCredSSPTrailerLength(len(message), cipherNegotiated)
+	if _, err := e.tlsConn.Write(message); err != nil {
+		return nil, err
+	}
+	sealedFirst, err := e.credsspConn.popOutgoing(credSSPTimeout(e.timeout))
+	if err != nil {
+		return nil, err
+	}
+	sealedMessage := e.credsspConn.drainOutgoing(sealedFirst)
 
-	// trailer := make([]byte, 4)
-	// binary.LittleEndian.PutUint32(trailer, uint32(trailerLength))
+	cipherSuite := tls.CipherSuiteName(e.tlsConn.ConnectionState().CipherSuite)
+	trailerLength := e.getCredSSPTrailerLength(len(message), cipherSuite)
 
-	// return append(trailer, sealedMessage...), nil
+	trailer := make([]byte, 4)
+	binary.LittleEndian.PutUint32(trailer, uint32(trailerLength))
+
+	return append(trailer, sealedMessage...), nil
 }
 
 func (e *Encryption) buildKerberosMessage(message []byte, host string) ([]byte, error) {
@@ -395,44 +439,68 @@ func (e *Encryption) buildKerberosMessage(message []byte, host string) ([]byte, 
 	// binary.LittleEndian.PutUint32(signatureLength, uint32(len(signature)))
 
 	// return append(append(signatureLength, signature...), sealedMessage...), nil
+	return nil, errors.New("kerberos encryption is not implemented")
 }
 
 func (e *Encryption) getCredSSPTrailerLength(messageLength int, cipherSuite string) int {
 	var trailerLength int
 
-	if match, _ := regexp.MatchString("^.*-GCM-[\\w\\d]*$", cipherSuite); match {
+	if strings.Contains(cipherSuite, "_GCM_") || strings.Contains(cipherSuite, "-GCM-") {
 		trailerLength = 16
 	} else {
-		hashAlgorithm := cipherSuite[strings.LastIndex(cipherSuite, "-")+1:]
-		var hashLength int
+		hashAlgorithm := ""
+		if strings.Contains(cipherSuite, "_") {
+			hashAlgorithm = cipherSuite[strings.LastIndex(cipherSuite, "_")+1:]
+		} else if strings.Contains(cipherSuite, "-") {
+			hashAlgorithm = cipherSuite[strings.LastIndex(cipherSuite, "-")+1:]
+		}
 
-		if hashAlgorithm == "MD5" {
+		var hashLength int
+		switch hashAlgorithm {
+		case "MD5":
 			hashLength = 16
-		} else if hashAlgorithm == "SHA" {
+		case "SHA":
 			hashLength = 20
-		} else if hashAlgorithm == "SHA256" {
+		case "SHA256":
 			hashLength = 32
-		} else if hashAlgorithm == "SHA384" {
+		case "SHA384":
 			hashLength = 48
-		} else {
+		default:
 			hashLength = 0
 		}
 
 		prePadLength := messageLength + hashLength
 		paddingLength := 0
 
-		if strings.Contains(cipherSuite, "RC4") {
+		if strings.Contains(cipherSuite, "RC4") || strings.Contains(cipherSuite, "CHACHA20") {
 			paddingLength = 0
-		} else if strings.Contains(cipherSuite, "DES") || strings.Contains(cipherSuite, "3DES") {
+		} else if strings.Contains(cipherSuite, "3DES") || strings.Contains(cipherSuite, "DES") {
 			paddingLength = 8 - (prePadLength % 8)
+			if paddingLength == 8 {
+				paddingLength = 0
+			}
 
 		} else {
 			// AES is a 128 bit block cipher
 			paddingLength = 16 - (prePadLength % 16)
+			if paddingLength == 16 {
+				paddingLength = 0
+			}
 		}
 
 		trailerLength = (prePadLength + paddingLength) - messageLength
 	}
 	return trailerLength
 }
-*/
+
+func splitUsername(input string) (string, string) {
+	if strings.Contains(input, "@") {
+		parts := strings.SplitN(input, "@", 2)
+		return parts[0], parts[1]
+	}
+	if strings.Contains(input, "\\") {
+		parts := strings.SplitN(input, "\\", 2)
+		return parts[1], parts[0]
+	}
+	return input, ""
+}


### PR DESCRIPTION
# Summary

Implements a `ClientCredSSP` transport for WinRM over CredSSP (MS-CSSP), enabling credential delegation. This PR adds the full handshake, message encryption, and wiring into the pluggable Transporter model, with unit tests and an opt-in live integration test.

Verified working in a live Active Directory environment with a Windows 11 client and Server 2025 server.

# Usage
```golang
params := winrm.DefaultParameters
params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientCredSSP{} }
client, err := winrm.NewClientWithParameters(endpoint, "DOMAIN\\user", "s3cr3t", params)
```

# Security
* pubKeyAuth channel binding for v2-v4 and v5+ (nonce + SHA-256); server key verified before delegation.
* `MinimumVersion` knob to refuse the pre-CVE-2018-0886 downgrade; sub-floor versions rejected.
* Correct MS-CSSP framing (`signature||sealed`, no length prefix); TLS pinned to 1.2; CA errors surfaced and `ServerName` defaulted.

# Robustness
* Single-connection pinning (auth state is per-connection) with one-shot re-handshake on a dropped-connection `401`.
* Real read deadlines (truncated responses time out instead of hanging).
* Surfaces tunnel-write failures, NTSTATUS `ErrorCode`, and HTTP error statuses; DER-length-based `TSRequest` framing.

# Testing
Unit tests (gocheck + `httptest`, run in normal CI): ASN.1 round-trips, wire-format/direction regressions, TLS build/decrypt incl. multi-record + tamper/timeout negatives, send-only vs reply-required flow, version negotiation, TLS-config edge cases, and a `-race` close/push test.

Opt-in live test behind `//go:build credssp_integration` + env guards, so default CI needs no Windows host:

`WINRM_CREDSSP_HOST=win-host WINRM_CREDSSP_USER='DOMAIN\user' WINRM_CREDSSP_PASSWORD=... go test -tags credssp_integration -run CredSSPIntegration ./...`

# Known limitations
* Requests are serialized (per-connection tunnel), so real-time interactive stdin isn't supported over CredSSP; `RunCmd`/`RunPS` are unaffected.
* No crypto-accurate end-to-end handshake unit test: `bodgit/ntlmssp` is client-only, so the handshake is covered at the seams plus the opt-in live test.